### PR TITLE
feat(mobile): add LLM smart shuffle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ apps/**/ios
 # Desloppify
 .desloppify/
 external-playlist-experiment/
+/temp/

--- a/apps/backend/src/env.ts
+++ b/apps/backend/src/env.ts
@@ -1,0 +1,7 @@
+export interface Env {
+	KV: {
+		get(key: string): Promise<string | null>
+	}
+	DATABASE_URL: string
+	JWT_SECRET: string
+}

--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 
+import type { Env } from './env'
 import authRoute from './routes/auth'
 import meRoute from './routes/me'
 import playlistsRoute from './routes/playlists'

--- a/apps/backend/src/middleware/auth.ts
+++ b/apps/backend/src/middleware/auth.ts
@@ -1,6 +1,7 @@
 import { createMiddleware } from 'hono/factory'
 import { verify } from 'hono/jwt'
 
+import type { Env } from '../env'
 import type { JwtTokenPayload } from '../types'
 
 /**

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -5,6 +5,7 @@ import { sign } from 'hono/jwt'
 
 import { createDb } from '../db'
 import { users } from '../db/schema'
+import type { Env } from '../env'
 import { loginRequestSchema } from '../validators/auth'
 
 /**

--- a/apps/backend/src/routes/me.ts
+++ b/apps/backend/src/routes/me.ts
@@ -3,6 +3,7 @@ import { Hono } from 'hono'
 
 import { createDb } from '../db'
 import { playlistMembers, sharedPlaylists } from '../db/schema'
+import type { Env } from '../env'
 import { authMiddleware } from '../middleware/auth'
 import type { JwtTokenPayload } from '../types'
 

--- a/apps/backend/src/routes/playlists.ts
+++ b/apps/backend/src/routes/playlists.ts
@@ -22,6 +22,7 @@ import {
 	sharedTracks,
 	users,
 } from '../db/schema'
+import type { Env } from '../env'
 import { authMiddleware } from '../middleware/auth'
 import type { ChangeEvent, JwtTokenPayload, TrackInput } from '../types'
 import {

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -8,6 +8,9 @@ import { version } from './package.json'
 
 const IS_DEV = process.env.APP_VARIANT === 'development'
 const IS_PREVIEW = process.env.APP_VARIANT === 'preview'
+const DEFAULT_ANDROID_ABI_FILTERS = IS_DEV
+	? ['arm64-v8a', 'x86_64']
+	: ['arm64-v8a']
 
 // 使用 git commit 数量作为 versionCode
 const getVersionCode = (): number => {
@@ -138,7 +141,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 					abiFilters:
 						typeof process.env.ABI_FILTERS === 'string'
 							? process.env.ABI_FILTERS.split(',')
-							: ['arm64-v8a'],
+							: DEFAULT_ANDROID_ABI_FILTERS,
 				},
 			],
 			[

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -244,6 +244,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 				},
 			],
 			'expo-web-browser',
+			'expo-secure-store',
 			'expo-sqlite',
 			'expo-router',
 			'@rnrepo/expo-config-plugin',

--- a/apps/mobile/drizzle/0019_smart_shuffle_tags.sql
+++ b/apps/mobile/drizzle/0019_smart_shuffle_tags.sql
@@ -1,0 +1,15 @@
+CREATE TABLE `track_llm_tags` (
+	`track_id` integer PRIMARY KEY NOT NULL,
+	`tags` text NOT NULL,
+	`confidence` real DEFAULT 0 NOT NULL,
+	`reason` text,
+	`model` text NOT NULL,
+	`source_type` text,
+	`source_id` text,
+	`source_synced_at` integer,
+	`indexed_at` integer DEFAULT (unixepoch() * 1000) NOT NULL,
+	FOREIGN KEY (`track_id`) REFERENCES `tracks`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `track_llm_tags_source_idx` ON `track_llm_tags` (`source_type`,`source_id`);--> statement-breakpoint
+CREATE INDEX `track_llm_tags_indexed_at_idx` ON `track_llm_tags` (`indexed_at`);

--- a/apps/mobile/drizzle/meta/_journal.json
+++ b/apps/mobile/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
 			"when": 1774146549533,
 			"tag": "0018_green_dracula",
 			"breakpoints": true
+		},
+		{
+			"idx": 19,
+			"version": "6",
+			"when": 1777250760000,
+			"tag": "0019_smart_shuffle_tags",
+			"breakpoints": true
 		}
 	]
 }

--- a/apps/mobile/drizzle/migrations.js
+++ b/apps/mobile/drizzle/migrations.js
@@ -19,6 +19,7 @@ import m0015 from './0015_flippant_skaar.sql'
 import m0016 from './0016_cheerful_stark_industries.sql'
 import m0017 from './0017_rare_lifeguard.sql'
 import m0018 from './0018_green_dracula.sql'
+import m0019 from './0019_smart_shuffle_tags.sql'
 import journal from './meta/_journal.json'
 
 export default {
@@ -43,5 +44,6 @@ export default {
 		m0016,
 		m0017,
 		m0018,
+		m0019,
 	},
 }

--- a/apps/mobile/eas.json
+++ b/apps/mobile/eas.json
@@ -13,7 +13,7 @@
 			},
 			"env": {
 				"APP_VARIANT": "development",
-				"ABI_FILTERS": "arm64-v8a"
+				"ABI_FILTERS": "arm64-v8a,x86_64"
 			}
 		},
 		"prod-v8a": {

--- a/apps/mobile/expo-plugins/withAbiFilters.js
+++ b/apps/mobile/expo-plugins/withAbiFilters.js
@@ -3,14 +3,23 @@ const {
 	withAppBuildGradle,
 } = require('expo/config-plugins')
 
+const ABI_FILTERS_BEGIN_MARKER = '// BEGIN expo-plugins/withAbiFilters'
+const ABI_FILTERS_END_MARKER = '// END expo-plugins/withAbiFilters'
+const MANAGED_ABI_FILTERS_BLOCK_REGEX = new RegExp(
+	`\\n\\s*${ABI_FILTERS_BEGIN_MARKER}\\s*\\r?\\n[\\s\\S]*?\\r?\\n\\s*${ABI_FILTERS_END_MARKER}\\s*\\r?\\n?`,
+	'g',
+)
+
 const upsertAbiFilters = (contents, abiFiltersString) => {
-	const ndkBlock = `        ndk {
+	const ndkBlock = `        ${ABI_FILTERS_BEGIN_MARKER}
+        ndk {
             abiFilters ${abiFiltersString}
         }
+        ${ABI_FILTERS_END_MARKER}
 `
 
 	const contentsWithoutManagedBlock = contents.replace(
-		/\n\s*ndk\s*\{\s*\n\s*abiFilters\s+[^\n]+\n\s*\}/g,
+		MANAGED_ABI_FILTERS_BLOCK_REGEX,
 		'',
 	)
 

--- a/apps/mobile/expo-plugins/withAbiFilters.js
+++ b/apps/mobile/expo-plugins/withAbiFilters.js
@@ -3,6 +3,23 @@ const {
 	withAppBuildGradle,
 } = require('expo/config-plugins')
 
+const upsertAbiFilters = (contents, abiFiltersString) => {
+	const ndkBlock = `        ndk {
+            abiFilters ${abiFiltersString}
+        }
+`
+
+	const contentsWithoutManagedBlock = contents.replace(
+		/\n\s*ndk\s*\{\s*\n\s*abiFilters\s+[^\n]+\n\s*\}/g,
+		'',
+	)
+
+	return contentsWithoutManagedBlock.replace(
+		/(defaultConfig\s*\{[ \t]*\r?\n)/,
+		`$1${ndkBlock}`,
+	)
+}
+
 const withAbiFilters = (config, { abiFilters = ['arm64-v8a'] } = {}) => {
 	// Set gradle.properties
 	config = withGradleProperties(config, (config) => {
@@ -27,15 +44,12 @@ const withAbiFilters = (config, { abiFilters = ['arm64-v8a'] } = {}) => {
 	config = withAppBuildGradle(config, (config) => {
 		const abiFiltersString = abiFilters.map((abi) => `"${abi}"`).join(', ')
 
-		// Add ndk abiFilters to defaultConfig
+		// Add ndk abiFilters to defaultConfig without depending on the
+		// generated build.gradle field order.
 		if (config.modResults.contents.includes('defaultConfig {')) {
-			config.modResults.contents = config.modResults.contents.replace(
-				/(defaultConfig\s*\{[^}]*versionName\s+[^}]*)/,
-				`$1
-        
-        ndk {
-            abiFilters ${abiFiltersString}
-        }`,
+			config.modResults.contents = upsertAbiFilters(
+				config.modResults.contents,
+				abiFiltersString,
 			)
 		}
 

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -4,12 +4,12 @@
 	"private": true,
 	"main": "index.js",
 	"scripts": {
-		"android": "WITH_ROZENITE=true expo run:android",
+		"android": "cross-env WITH_ROZENITE=true expo run:android",
 		"format": "eslint . --fix && oxfmt --write .",
 		"lint": "eslint .",
 		"postinstall": "patch-package",
 		"prepare": "pbjs -t static-module -w commonjs -o src/lib/api/bilibili/proto/dm.js src/lib/api/bilibili/proto/dm.proto && pbts -o src/lib/api/bilibili/proto/dm.d.ts src/lib/api/bilibili/proto/dm.js",
-		"start": "WITH_ROZENITE=true APP_VARIANT=development expo start",
+		"start": "cross-env WITH_ROZENITE=true APP_VARIANT=development expo start",
 		"test": "jest --watchAll"
 	},
 	"dependencies": {
@@ -136,6 +136,7 @@
 		"babel-plugin-inline-import": "^3.0.0",
 		"babel-plugin-react-compiler": "19.1.0-rc.1",
 		"babel-plugin-transform-remove-console": "^6.9.4",
+		"cross-env": "^10.1.0",
 		"drizzle-kit": "^0.31.9",
 		"eslint": "^9.39.2",
 		"eslint-config-expo": "~55.0.0",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -63,6 +63,7 @@
 		"expo-linking": "~55.0.7",
 		"expo-media-library": "~55.0.9",
 		"expo-router": "55.0.3",
+		"expo-secure-store": "~55.0.13",
 		"expo-sharing": "~55.0.11",
 		"expo-splash-screen": "~55.0.10",
 		"expo-sqlite": "~55.0.10",

--- a/apps/mobile/src/app/downloaded.tsx
+++ b/apps/mobile/src/app/downloaded.tsx
@@ -578,7 +578,7 @@ export default function DownloadedPage() {
 								await Orpheus.playNext(currentMenuTask.track)
 								toast.success('添加到下一首播放成功')
 							} catch (error) {
-								toastAndLogError(error, '添加到下一首播放失败')
+								toastAndLogError('添加到下一首播放失败', error, 'Downloaded')
 							}
 						}
 						dismissItemMenu()

--- a/apps/mobile/src/app/playlist/local/[id].tsx
+++ b/apps/mobile/src/app/playlist/local/[id].tsx
@@ -769,6 +769,9 @@ export default function LocalPlaylistPage() {
 							playlist={playlistMetadata}
 							totalDuration={playlistMetadata.totalDuration}
 							onClickPlayAll={playAll}
+							onClickSmartShuffle={() =>
+								openModal('SmartShuffle', { playlistId: Number(id) })
+							}
 							onClickSync={handleSync}
 							onClickCopyToLocalPlaylist={() =>
 								openModal('DuplicateLocalPlaylist', {

--- a/apps/mobile/src/app/settings/playback.tsx
+++ b/apps/mobile/src/app/settings/playback.tsx
@@ -95,6 +95,26 @@ export default function PlaybackSettingsPage() {
 						}
 					/>
 				</View>
+
+				<View style={styles.settingRow}>
+					<View style={styles.settingText}>
+						<Text>智能随机播放</Text>
+						<Text
+							variant='bodySmall'
+							style={styles.description}
+						>
+							配置 OpenAI 兼容 LLM API、标签索引和默认听歌取向
+						</Text>
+					</View>
+					<IconButton
+						icon='shuffle-variant'
+						onPress={() =>
+							useModalStore
+								.getState()
+								.open('LlmSmartShuffleSettings', undefined)
+						}
+					/>
+				</View>
 			</ScrollView>
 			<View style={styles.nowPlayingBarContainer}>
 				<NowPlayingBar />
@@ -118,6 +138,14 @@ const styles = StyleSheet.create({
 		alignItems: 'center',
 		justifyContent: 'space-between',
 		marginTop: 16,
+	},
+	settingText: {
+		flex: 1,
+		marginRight: 16,
+	},
+	description: {
+		opacity: 0.7,
+		marginTop: 4,
 	},
 	nowPlayingBarContainer: {
 		position: 'absolute',

--- a/apps/mobile/src/components/ModalRegistry.tsx
+++ b/apps/mobile/src/components/ModalRegistry.tsx
@@ -65,6 +65,12 @@ const DanmakuSettingsModal = lazy(
 const CoverDownloadProgressModal = lazy(
 	() => import('./modals/settings/CoverDownloadProgressModal'),
 )
+const LlmSmartShuffleSettingsModal = lazy(
+	() => import('./modals/settings/LlmSmartShuffleSettingsModal'),
+)
+const SmartShuffleModal = lazy(
+	() => import('./modals/playlist/SmartShuffleModal'),
+)
 const EnableSharingModal = lazy(
 	() => import('./modals/playlist/EnableSharingModal'),
 )
@@ -105,6 +111,8 @@ export const modalRegistry: { [K in ModalKey]: ModalComponent<K> } = {
 	ManualMatchExternalSync: ManualMatchExternalSyncModal,
 	DanmakuSettings: DanmakuSettingsModal,
 	CoverDownloadProgress: CoverDownloadProgressModal,
+	LlmSmartShuffleSettings: LlmSmartShuffleSettingsModal,
+	SmartShuffle: SmartShuffleModal,
 	EnableSharing: EnableSharingModal,
 	SubscribeToSharedPlaylist: SubscribeToSharedPlaylistModal,
 	MergePlaylists: MergePlaylistsModal,

--- a/apps/mobile/src/components/modals/playlist/SmartShuffleModal.tsx
+++ b/apps/mobile/src/components/modals/playlist/SmartShuffleModal.tsx
@@ -49,7 +49,9 @@ export default function SmartShuffleModal({
 			}
 
 			const tracks = tracksResult.value.filter((item) =>
-				item.source === 'bilibili' ? item.bilibiliMetadata.videoIsValid : true,
+				item.source === 'bilibili'
+					? (item.bilibiliMetadata?.videoIsValid ?? false)
+					: true,
 			)
 			if (tracks.length === 0) {
 				toast.show('没有可播放的歌曲')
@@ -57,12 +59,25 @@ export default function SmartShuffleModal({
 				return
 			}
 
-			const smartQueue = await llmSmartShuffleService.createSmartQueue(tracks, {
-				prompt,
-				defaultPreference,
-			})
+			const smartQueueResult = await llmSmartShuffleService.createSmartQueue(
+				tracks,
+				{
+					prompt,
+					defaultPreference,
+				},
+			)
+			if (smartQueueResult.isErr()) {
+				toastAndLogError(
+					'智能随机播放失败',
+					smartQueueResult.error,
+					'SmartShuffle',
+				)
+				setIsLoading(false)
+				return
+			}
+
 			await addToQueue({
-				tracks: smartQueue,
+				tracks: smartQueueResult.value,
 				playNow: true,
 				clearQueue: true,
 				playNext: false,

--- a/apps/mobile/src/components/modals/playlist/SmartShuffleModal.tsx
+++ b/apps/mobile/src/components/modals/playlist/SmartShuffleModal.tsx
@@ -1,0 +1,142 @@
+import { useState } from 'react'
+import { StyleSheet, View } from 'react-native'
+import { Chip, Dialog, Text, TextInput } from 'react-native-paper'
+
+import Button from '@/components/common/Button'
+import useAppStore from '@/hooks/stores/useAppStore'
+import { useModalStore } from '@/hooks/stores/useModalStore'
+import { llmSmartShuffleService } from '@/lib/services/llmSmartShuffleService'
+import { playlistService } from '@/lib/services/playlistService'
+import { toastAndLogError } from '@/utils/error-handling'
+import { addToQueue } from '@/utils/player'
+import toast from '@/utils/toast'
+
+const QUICK_PROMPTS = [
+	'多听点中V',
+	'最近收藏的歌曲',
+	'老收藏回顾',
+	'冷门随机',
+	'工作学习',
+	'夜晚放松',
+	'燃一点',
+	'治愈一点',
+]
+
+export default function SmartShuffleModal({
+	playlistId,
+}: {
+	playlistId: number
+}) {
+	const close = useModalStore((state) => state.close)
+	const defaultPreference = useAppStore(
+		(state) => state.settings.llmDefaultPreference,
+	)
+	const [prompt, setPrompt] = useState(defaultPreference)
+	const [isLoading, setIsLoading] = useState(false)
+
+	const handlePlay = async () => {
+		setIsLoading(true)
+		try {
+			const tracksResult = await playlistService.getPlaylistTracks(playlistId)
+			if (tracksResult.isErr()) {
+				toastAndLogError('获取播放列表内容失败', tracksResult.error, 'SmartShuffle')
+				setIsLoading(false)
+				return
+			}
+
+			const tracks = tracksResult.value.filter((item) =>
+				item.source === 'bilibili' ? item.bilibiliMetadata.videoIsValid : true,
+			)
+			if (tracks.length === 0) {
+				toast.show('没有可播放的歌曲')
+				setIsLoading(false)
+				return
+			}
+
+			const smartQueue = await llmSmartShuffleService.createSmartQueue(tracks, {
+				prompt,
+				defaultPreference,
+			})
+			await addToQueue({
+				tracks: smartQueue,
+				playNow: true,
+				clearQueue: true,
+				playNext: false,
+			})
+			toast.success('已按取向生成智能随机队列')
+			close('SmartShuffle')
+		} catch (error) {
+			toastAndLogError('智能随机播放失败', error, 'SmartShuffle')
+		}
+		setIsLoading(false)
+	}
+
+	return (
+		<>
+			<Dialog.Title>智能随机播放</Dialog.Title>
+			<Dialog.Content>
+				<Text
+					variant='bodySmall'
+					style={styles.description}
+				>
+					描述这次想听什么，或直接点一个快捷取向。系统会根据本地标签索引生成播放队列。
+				</Text>
+				<TextInput
+					label='这次想听什么？'
+					value={prompt}
+					onChangeText={setPrompt}
+					mode='outlined'
+					multiline
+					numberOfLines={4}
+					textAlignVertical='top'
+					style={styles.input}
+					placeholder='例如：我想多听点中V，穿插一些最近收藏'
+				/>
+				<View style={styles.chips}>
+					{QUICK_PROMPTS.map((item) => (
+						<Chip
+							key={item}
+							onPress={() => setPrompt(item)}
+							style={styles.chip}
+						>
+							{item}
+						</Chip>
+					))}
+				</View>
+			</Dialog.Content>
+			<Dialog.Actions>
+				<Button
+					onPress={() => close('SmartShuffle')}
+					disabled={isLoading}
+				>
+					取消
+				</Button>
+				<Button
+					onPress={handlePlay}
+					disabled={isLoading}
+				>
+					开始播放
+				</Button>
+			</Dialog.Actions>
+		</>
+	)
+}
+
+const styles = StyleSheet.create({
+	description: {
+		marginBottom: 12,
+		opacity: 0.75,
+	},
+	input: {
+		maxHeight: 140,
+	},
+	chips: {
+		flexDirection: 'row',
+		flexWrap: 'wrap',
+		marginTop: 12,
+	},
+	chip: {
+		marginRight: 8,
+		marginBottom: 8,
+	},
+})

--- a/apps/mobile/src/components/modals/playlist/SmartShuffleModal.tsx
+++ b/apps/mobile/src/components/modals/playlist/SmartShuffleModal.tsx
@@ -39,7 +39,11 @@ export default function SmartShuffleModal({
 		try {
 			const tracksResult = await playlistService.getPlaylistTracks(playlistId)
 			if (tracksResult.isErr()) {
-				toastAndLogError('获取播放列表内容失败', tracksResult.error, 'SmartShuffle')
+				toastAndLogError(
+					'获取播放列表内容失败',
+					tracksResult.error,
+					'SmartShuffle',
+				)
 				setIsLoading(false)
 				return
 			}
@@ -63,7 +67,7 @@ export default function SmartShuffleModal({
 				clearQueue: true,
 				playNext: false,
 			})
-			toast.success('已按取向生成智能随机队列')
+			toast.success('已按取向生成智能排序队列')
 			close('SmartShuffle')
 		} catch (error) {
 			toastAndLogError('智能随机播放失败', error, 'SmartShuffle')
@@ -79,7 +83,8 @@ export default function SmartShuffleModal({
 					variant='bodySmall'
 					style={styles.description}
 				>
-					描述这次想听什么，或直接点一个快捷取向。系统会根据本地标签索引生成播放队列。
+					描述这次想听什么，或直接点一个快捷取向。系统会让 LLM
+					基于整份歌单生成播放队列，失败时回退到本地标签排序。
 				</Text>
 				<TextInput
 					label='这次想听什么？'

--- a/apps/mobile/src/components/modals/settings/LlmSmartShuffleSettingsModal.tsx
+++ b/apps/mobile/src/components/modals/settings/LlmSmartShuffleSettingsModal.tsx
@@ -88,7 +88,8 @@ export default function LlmSmartShuffleSettingsModal() {
 								variant='bodySmall'
 								style={styles.description}
 							>
-								同步收藏夹后读取标题和基础元数据，生成本地标签索引。
+								同步收藏夹后读取标题和基础元数据，生成本地标签索引，并用于 LLM
+								排序。
 							</Text>
 						</View>
 						<Switch

--- a/apps/mobile/src/components/modals/settings/LlmSmartShuffleSettingsModal.tsx
+++ b/apps/mobile/src/components/modals/settings/LlmSmartShuffleSettingsModal.tsx
@@ -121,6 +121,8 @@ export default function LlmSmartShuffleSettingsModal() {
 						mode='outlined'
 						style={styles.input}
 						placeholder='https://api.openai.com/v1'
+						autoCapitalize='none'
+						autoCorrect={false}
 					/>
 					<TextInput
 						label='API Key'
@@ -130,6 +132,8 @@ export default function LlmSmartShuffleSettingsModal() {
 						style={styles.input}
 						secureTextEntry
 						disabled={isLoadingApiKey}
+						autoCapitalize='none'
+						autoCorrect={false}
 					/>
 					<TextInput
 						label='模型名称'
@@ -138,6 +142,8 @@ export default function LlmSmartShuffleSettingsModal() {
 						mode='outlined'
 						style={styles.input}
 						placeholder='gpt-4o-mini'
+						autoCapitalize='none'
+						autoCorrect={false}
 					/>
 					<TextInput
 						label='默认听歌取向'

--- a/apps/mobile/src/components/modals/settings/LlmSmartShuffleSettingsModal.tsx
+++ b/apps/mobile/src/components/modals/settings/LlmSmartShuffleSettingsModal.tsx
@@ -1,0 +1,148 @@
+import { useState } from 'react'
+import { ScrollView, StyleSheet, View } from 'react-native'
+import { Dialog, Switch, Text, TextInput } from 'react-native-paper'
+
+import Button from '@/components/common/Button'
+import useAppStore from '@/hooks/stores/useAppStore'
+import { useModalStore } from '@/hooks/stores/useModalStore'
+import toast from '@/utils/toast'
+
+export default function LlmSmartShuffleSettingsModal() {
+	const settings = useAppStore((state) => state.settings)
+	const setSettings = useAppStore((state) => state.setSettings)
+	const close = useModalStore((state) => state.close)
+
+	const [enableLlmTagging, setEnableLlmTagging] = useState(
+		settings.enableLlmTagging,
+	)
+	const [allowLlmMetadataUpload, setAllowLlmMetadataUpload] = useState(
+		settings.allowLlmMetadataUpload,
+	)
+	const [llmBaseUrl, setLlmBaseUrl] = useState(settings.llmBaseUrl)
+	const [llmApiKey, setLlmApiKey] = useState(settings.llmApiKey)
+	const [llmModel, setLlmModel] = useState(settings.llmModel)
+	const [llmDefaultPreference, setLlmDefaultPreference] = useState(
+		settings.llmDefaultPreference,
+	)
+
+	const handleSave = () => {
+		setSettings({
+			enableLlmTagging,
+			allowLlmMetadataUpload,
+			llmBaseUrl: llmBaseUrl.trim() || 'https://api.openai.com/v1',
+			llmApiKey: llmApiKey.trim(),
+			llmModel: llmModel.trim() || 'gpt-4o-mini',
+			llmDefaultPreference: llmDefaultPreference.trim(),
+		})
+		toast.success('智能随机播放设置已保存')
+		close('LlmSmartShuffleSettings')
+	}
+
+	return (
+		<>
+			<Dialog.Title>智能随机播放</Dialog.Title>
+			<Dialog.Content>
+				<ScrollView style={styles.content}>
+					<View style={styles.row}>
+						<View style={styles.rowText}>
+							<Text>启用 LLM 标签索引</Text>
+							<Text
+								variant='bodySmall'
+								style={styles.description}
+							>
+								同步收藏夹后读取标题和基础元数据，生成本地标签索引。
+							</Text>
+						</View>
+						<Switch
+							value={enableLlmTagging}
+							onValueChange={setEnableLlmTagging}
+						/>
+					</View>
+
+					<View style={styles.row}>
+						<View style={styles.rowText}>
+							<Text>允许上传标题和基础元数据</Text>
+							<Text
+								variant='bodySmall'
+								style={styles.description}
+							>
+								不会上传音频文件、Cookie 或完整播放历史。
+							</Text>
+						</View>
+						<Switch
+							value={allowLlmMetadataUpload}
+							onValueChange={setAllowLlmMetadataUpload}
+						/>
+					</View>
+
+					<TextInput
+						label='OpenAI 兼容 API 地址'
+						value={llmBaseUrl}
+						onChangeText={setLlmBaseUrl}
+						mode='outlined'
+						style={styles.input}
+						placeholder='https://api.openai.com/v1'
+					/>
+					<TextInput
+						label='API Key'
+						value={llmApiKey}
+						onChangeText={setLlmApiKey}
+						mode='outlined'
+						style={styles.input}
+						secureTextEntry
+					/>
+					<TextInput
+						label='模型名称'
+						value={llmModel}
+						onChangeText={setLlmModel}
+						mode='outlined'
+						style={styles.input}
+						placeholder='gpt-4o-mini'
+					/>
+					<TextInput
+						label='默认听歌取向'
+						value={llmDefaultPreference}
+						onChangeText={setLlmDefaultPreference}
+						mode='outlined'
+						style={styles.preferenceInput}
+						multiline
+						numberOfLines={4}
+						textAlignVertical='top'
+						placeholder='例如：多听点中V和最近收藏，少听太吵的歌'
+					/>
+				</ScrollView>
+			</Dialog.Content>
+			<Dialog.Actions>
+				<Button onPress={() => close('LlmSmartShuffleSettings')}>取消</Button>
+				<Button onPress={handleSave}>保存</Button>
+			</Dialog.Actions>
+		</>
+	)
+}
+
+const styles = StyleSheet.create({
+	content: {
+		maxHeight: 520,
+	},
+	row: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		marginBottom: 16,
+	},
+	rowText: {
+		flex: 1,
+		marginRight: 16,
+	},
+	description: {
+		marginTop: 4,
+		opacity: 0.7,
+	},
+	input: {
+		marginBottom: 12,
+	},
+	preferenceInput: {
+		marginBottom: 4,
+		maxHeight: 140,
+	},
+})

--- a/apps/mobile/src/components/modals/settings/LlmSmartShuffleSettingsModal.tsx
+++ b/apps/mobile/src/components/modals/settings/LlmSmartShuffleSettingsModal.tsx
@@ -1,10 +1,12 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { ScrollView, StyleSheet, View } from 'react-native'
 import { Dialog, Switch, Text, TextInput } from 'react-native-paper'
 
 import Button from '@/components/common/Button'
 import useAppStore from '@/hooks/stores/useAppStore'
 import { useModalStore } from '@/hooks/stores/useModalStore'
+import { llmCredentialService } from '@/lib/services/llmCredentialService'
+import { toastAndLogError } from '@/utils/error-handling'
 import toast from '@/utils/toast'
 
 export default function LlmSmartShuffleSettingsModal() {
@@ -19,18 +21,54 @@ export default function LlmSmartShuffleSettingsModal() {
 		settings.allowLlmMetadataUpload,
 	)
 	const [llmBaseUrl, setLlmBaseUrl] = useState(settings.llmBaseUrl)
-	const [llmApiKey, setLlmApiKey] = useState(settings.llmApiKey)
+	const [llmApiKey, setLlmApiKey] = useState('')
 	const [llmModel, setLlmModel] = useState(settings.llmModel)
 	const [llmDefaultPreference, setLlmDefaultPreference] = useState(
 		settings.llmDefaultPreference,
 	)
+	const [isLoadingApiKey, setIsLoadingApiKey] = useState(true)
 
-	const handleSave = () => {
+	useEffect(() => {
+		let isMounted = true
+		llmCredentialService
+			.migrateFromPlainSettings()
+			.then(() => llmCredentialService.getApiKey())
+			.then((apiKey) => {
+				if (!isMounted) return
+				setLlmApiKey(apiKey)
+			})
+			.catch((error) => {
+				toastAndLogError(
+					'读取 LLM API Key 失败',
+					error,
+					'LlmSmartShuffleSettings',
+				)
+			})
+			.finally(() => {
+				if (!isMounted) return
+				setIsLoadingApiKey(false)
+			})
+
+		return () => {
+			isMounted = false
+		}
+	}, [])
+
+	const handleSave = async () => {
+		try {
+			await llmCredentialService.setApiKey(llmApiKey)
+		} catch (error) {
+			toastAndLogError(
+				'保存 LLM API Key 失败',
+				error,
+				'LlmSmartShuffleSettings',
+			)
+			return
+		}
 		setSettings({
 			enableLlmTagging,
 			allowLlmMetadataUpload,
 			llmBaseUrl: llmBaseUrl.trim() || 'https://api.openai.com/v1',
-			llmApiKey: llmApiKey.trim(),
 			llmModel: llmModel.trim() || 'gpt-4o-mini',
 			llmDefaultPreference: llmDefaultPreference.trim(),
 		})
@@ -90,6 +128,7 @@ export default function LlmSmartShuffleSettingsModal() {
 						mode='outlined'
 						style={styles.input}
 						secureTextEntry
+						disabled={isLoadingApiKey}
 					/>
 					<TextInput
 						label='模型名称'
@@ -114,7 +153,12 @@ export default function LlmSmartShuffleSettingsModal() {
 			</Dialog.Content>
 			<Dialog.Actions>
 				<Button onPress={() => close('LlmSmartShuffleSettings')}>取消</Button>
-				<Button onPress={handleSave}>保存</Button>
+				<Button
+					onPress={handleSave}
+					disabled={isLoadingApiKey}
+				>
+					保存
+				</Button>
 			</Dialog.Actions>
 		</>
 	)

--- a/apps/mobile/src/features/playlist/local/components/LocalPlaylistHeader.tsx
+++ b/apps/mobile/src/features/playlist/local/components/LocalPlaylistHeader.tsx
@@ -30,6 +30,7 @@ interface PlaylistHeaderProps {
 	playlist: Playlist & { validTrackCount: number }
 	totalDuration?: number
 	onClickPlayAll: () => void
+	onClickSmartShuffle: () => void
 	onClickSync: () => void
 	onClickCopyToLocalPlaylist: () => void
 	/** 当作者为 bilibili 时触发。可选，未提供时仅视觉提示不响应 */
@@ -88,6 +89,7 @@ export const PlaylistHeader = memo(function PlaylistHeader({
 	playlist,
 	totalDuration,
 	onClickPlayAll,
+	onClickSmartShuffle,
 	onClickSync,
 	onClickCopyToLocalPlaylist,
 	onPressAuthor,
@@ -352,6 +354,14 @@ export const PlaylistHeader = memo(function PlaylistHeader({
 					>
 						播放全部
 					</Button>
+
+					<IconButton
+						mode='contained'
+						icon='shuffle-variant'
+						size={20}
+						onPress={onClickSmartShuffle}
+						testID='playlist-smart-shuffle'
+					/>
 
 					{playlist.type !== 'local' && (
 						<IconButton

--- a/apps/mobile/src/hooks/stores/useAppStore.ts
+++ b/apps/mobile/src/hooks/stores/useAppStore.ts
@@ -111,7 +111,6 @@ export const useAppStore = create<AppState>()(
 					enableLlmTagging: false,
 					allowLlmMetadataUpload: false,
 					llmBaseUrl: 'https://api.openai.com/v1',
-					llmApiKey: '',
 					llmModel: 'gpt-4o-mini',
 					llmDefaultPreference: '',
 				},
@@ -255,6 +254,7 @@ export const useAppStore = create<AppState>()(
 					delete mergedState.settings.enableSentryReport
 					// @ts-expect-error -- cleanup
 					delete mergedState.settings.enableAnalytics
+					delete mergedState.settings.llmApiKey
 
 					return mergedState
 				}

--- a/apps/mobile/src/hooks/stores/useAppStore.ts
+++ b/apps/mobile/src/hooks/stores/useAppStore.ts
@@ -108,6 +108,12 @@ export const useAppStore = create<AppState>()(
 					enableDataCollection: true,
 					enableDanmaku: false,
 					danmakuFilterLevel: 0,
+					enableLlmTagging: false,
+					allowLlmMetadataUpload: false,
+					llmBaseUrl: 'https://api.openai.com/v1',
+					llmApiKey: '',
+					llmModel: 'gpt-4o-mini',
+					llmDefaultPreference: '',
 				},
 				bilibiliUserInfo: null,
 

--- a/apps/mobile/src/lib/db/schema.ts
+++ b/apps/mobile/src/lib/db/schema.ts
@@ -4,6 +4,7 @@ import {
 	index,
 	integer,
 	primaryKey,
+	real,
 	sqliteTable,
 	text,
 	uniqueIndex,
@@ -181,6 +182,41 @@ export const localMetadata = sqliteTable('local_metadata', {
 	localPath: text('local_path').notNull(),
 })
 
+export const trackLlmTags = sqliteTable(
+	'track_llm_tags',
+	{
+		trackId: integer('track_id')
+			.primaryKey()
+			.references(() => tracks.id, { onDelete: 'cascade' }),
+		tags: text('tags', { mode: 'json' })
+			.$type<{
+				language: string[]
+				vocalType: string[]
+				genre: string[]
+				mood: string[]
+				scene: string[]
+				timePreference: string[]
+			}>()
+			.notNull(),
+		confidence: real('confidence').notNull().default(0),
+		reason: text('reason'),
+		model: text('model').notNull(),
+		sourceType: text('source_type', {
+			enum: ['favorite', 'collection', 'multi_page', 'local'],
+		}),
+		sourceId: text('source_id'),
+		sourceSyncedAt: integer('source_synced_at', { mode: 'timestamp_ms' }),
+		indexedAt: integer('indexed_at', { mode: 'timestamp_ms' })
+			.notNull()
+			.default(sql`(unixepoch() * 1000)`)
+			.$onUpdate(() => new Date()),
+	},
+	(table) => [
+		index('track_llm_tags_source_idx').on(table.sourceType, table.sourceId),
+		index('track_llm_tags_indexed_at_idx').on(table.indexedAt),
+	],
+)
+
 export const playlistSyncQueue = sqliteTable(
 	'playlist_sync_queue',
 	{
@@ -234,6 +270,10 @@ export const trackRelations = relations(tracks, ({ one, many }) => ({
 		fields: [tracks.id],
 		references: [localMetadata.trackId],
 	}),
+	llmTags: one(trackLlmTags, {
+		fields: [tracks.id],
+		references: [trackLlmTags.trackId],
+	}),
 	playHistory: many(playHistory),
 }))
 
@@ -276,6 +316,13 @@ export const bilibiliMetadataRelations = relations(
 export const localMetadataRelations = relations(localMetadata, ({ one }) => ({
 	track: one(tracks, {
 		fields: [localMetadata.trackId],
+		references: [tracks.id],
+	}),
+}))
+
+export const trackLlmTagsRelations = relations(trackLlmTags, ({ one }) => ({
+	track: one(tracks, {
+		fields: [trackLlmTags.trackId],
 		references: [tracks.id],
 	}),
 }))

--- a/apps/mobile/src/lib/facades/syncBilibiliPlaylist.ts
+++ b/apps/mobile/src/lib/facades/syncBilibiliPlaylist.ts
@@ -262,11 +262,17 @@ export class SyncBilibiliPlaylistFacade {
 								)
 								return playlistRes.value.id
 							})
-							await llmSmartShuffleService.indexPlaylistTracks(playlistId, {
-								sourceType: 'collection',
-								sourceId: String(collectionId),
-								sourceSyncedAt: new Date(),
-							})
+							const indexResult =
+								await llmSmartShuffleService.indexPlaylistTracks(playlistId, {
+									sourceType: 'collection',
+									sourceId: String(collectionId),
+									sourceSyncedAt: new Date(),
+								})
+							if (indexResult.isErr()) {
+								logger.warning('LLM 标签索引失败', {
+									error: indexResult.error,
+								})
+							}
 							return playlistId
 						})(),
 						(e) =>
@@ -310,10 +316,10 @@ export class SyncBilibiliPlaylistFacade {
 					})
 					return ResultAsync.fromPromise(
 						(async () => {
-							const playlistId = await this.db.transaction(async () => {
-								const playlistSvc = this.playlistService.withDB(this.db)
-								const trackSvc = this.trackService.withDB(this.db)
-								const artistSvc = this.artistService.withDB(this.db)
+							const playlistId = await this.db.transaction(async (tx) => {
+								const playlistSvc = this.playlistService.withDB(tx)
+								const trackSvc = this.trackService.withDB(tx)
+								const artistSvc = this.artistService.withDB(tx)
 
 								const playlistAuthor = await artistSvc.findOrCreateArtist({
 									name: data.owner.name,
@@ -386,11 +392,17 @@ export class SyncBilibiliPlaylistFacade {
 
 								return playlistRes.value.id
 							})
-							await llmSmartShuffleService.indexPlaylistTracks(playlistId, {
-								sourceType: 'multi_page',
-								sourceId: bvid,
-								sourceSyncedAt: new Date(),
-							})
+							const indexResult =
+								await llmSmartShuffleService.indexPlaylistTracks(playlistId, {
+									sourceType: 'multi_page',
+									sourceId: bvid,
+									sourceSyncedAt: new Date(),
+								})
+							if (indexResult.isErr()) {
+								logger.warning('LLM 标签索引失败', {
+									error: indexResult.error,
+								})
+							}
 							return playlistId
 						})(),
 						(e) =>
@@ -805,11 +817,17 @@ export class SyncBilibiliPlaylistFacade {
 				message: '正在创建 LLM 标签索引...',
 				stage: 'indexing',
 			})
-			await llmSmartShuffleService.indexPlaylistTracks(txResult.value, {
-				sourceType: 'favorite',
-				sourceId: String(favoriteId),
-				sourceSyncedAt: new Date(),
-			})
+			const indexResult = await llmSmartShuffleService.indexPlaylistTracks(
+				txResult.value,
+				{
+					sourceType: 'favorite',
+					sourceId: String(favoriteId),
+					sourceSyncedAt: new Date(),
+				},
+			)
+			if (indexResult.isErr()) {
+				logger.warning('LLM 标签索引失败', { error: indexResult.error })
+			}
 			onProgress?.({
 				message: '正在创建 LLM 排序 JSON...',
 				stage: 'creating_dataset',

--- a/apps/mobile/src/lib/facades/syncBilibiliPlaylist.ts
+++ b/apps/mobile/src/lib/facades/syncBilibiliPlaylist.ts
@@ -18,6 +18,7 @@ import { analyticsService } from '@/lib/services/analyticsService'
 import type { ArtistService } from '@/lib/services/artistService'
 import { artistService } from '@/lib/services/artistService'
 import generateUniqueTrackKey from '@/lib/services/genKey'
+import { llmSmartShuffleService } from '@/lib/services/llmSmartShuffleService'
 import type { PlaylistService } from '@/lib/services/playlistService'
 import { playlistService } from '@/lib/services/playlistService'
 import type { TrackService } from '@/lib/services/trackService'
@@ -39,6 +40,7 @@ export interface FavoriteSyncProgress {
 		| 'calculating_diff'
 		| 'fetching_details'
 		| 'saving'
+		| 'indexing'
 		| 'completed'
 		| 'error'
 }
@@ -161,7 +163,8 @@ export class SyncBilibiliPlaylistFacade {
 						)
 					}
 					return ResultAsync.fromPromise(
-						this.db.transaction(async (tx) => {
+						(async () => {
+							const playlistId = await this.db.transaction(async (tx) => {
 							const playlistSvc = this.playlistService.withDB(tx)
 							const trackSvc = this.trackService.withDB(tx)
 							const artistSvc = this.artistService.withDB(tx)
@@ -250,7 +253,14 @@ export class SyncBilibiliPlaylistFacade {
 								trackIds.length,
 							)
 							return playlistRes.value.id
-						}),
+							})
+							await llmSmartShuffleService.indexPlaylistTracks(playlistId, {
+								sourceType: 'collection',
+								sourceId: String(collectionId),
+								sourceSyncedAt: new Date(),
+							})
+							return playlistId
+						})(),
 						(e) =>
 							createFacadeError('SyncCollectionFailed', '同步合集失败', {
 								cause: e,
@@ -291,7 +301,8 @@ export class SyncBilibiliPlaylistFacade {
 						pages: data.pages.length,
 					})
 					return ResultAsync.fromPromise(
-						this.db.transaction(async () => {
+						(async () => {
+							const playlistId = await this.db.transaction(async () => {
 							const playlistSvc = this.playlistService.withDB(this.db)
 							const trackSvc = this.trackService.withDB(this.db)
 							const artistSvc = this.artistService.withDB(this.db)
@@ -361,7 +372,14 @@ export class SyncBilibiliPlaylistFacade {
 							)
 
 							return playlistRes.value.id
-						}),
+							})
+							await llmSmartShuffleService.indexPlaylistTracks(playlistId, {
+								sourceType: 'multi_page',
+								sourceId: bvid,
+								sourceSyncedAt: new Date(),
+							})
+							return playlistId
+						})(),
 						(e) =>
 							createFacadeError('SyncMultiPageFailed', '同步多集视频失败', {
 								cause: e,
@@ -751,6 +769,15 @@ export class SyncBilibiliPlaylistFacade {
 			if (txResult.isErr()) {
 				return err(txResult.error)
 			}
+			onProgress?.({
+				message: '正在创建 LLM 标签索引...',
+				stage: 'indexing',
+			})
+			await llmSmartShuffleService.indexPlaylistTracks(txResult.value, {
+				sourceType: 'favorite',
+				sourceId: String(favoriteId),
+				sourceSyncedAt: new Date(),
+			})
 			return ok(txResult.value)
 		} finally {
 			this.syncingIds.delete(`favorite::${favoriteId}`)

--- a/apps/mobile/src/lib/facades/syncBilibiliPlaylist.ts
+++ b/apps/mobile/src/lib/facades/syncBilibiliPlaylist.ts
@@ -18,6 +18,7 @@ import { analyticsService } from '@/lib/services/analyticsService'
 import type { ArtistService } from '@/lib/services/artistService'
 import { artistService } from '@/lib/services/artistService'
 import generateUniqueTrackKey from '@/lib/services/genKey'
+import { llmSmartShuffleDatasetService } from '@/lib/services/llmSmartShuffleDatasetService'
 import { llmSmartShuffleService } from '@/lib/services/llmSmartShuffleService'
 import type { PlaylistService } from '@/lib/services/playlistService'
 import { playlistService } from '@/lib/services/playlistService'
@@ -41,6 +42,7 @@ export interface FavoriteSyncProgress {
 		| 'fetching_details'
 		| 'saving'
 		| 'indexing'
+		| 'creating_dataset'
 		| 'completed'
 		| 'error'
 }
@@ -165,94 +167,100 @@ export class SyncBilibiliPlaylistFacade {
 					return ResultAsync.fromPromise(
 						(async () => {
 							const playlistId = await this.db.transaction(async (tx) => {
-							const playlistSvc = this.playlistService.withDB(tx)
-							const trackSvc = this.trackService.withDB(tx)
-							const artistSvc = this.artistService.withDB(tx)
+								const playlistSvc = this.playlistService.withDB(tx)
+								const trackSvc = this.trackService.withDB(tx)
+								const artistSvc = this.artistService.withDB(tx)
 
-							const playlistArtistId = await artistSvc.findOrCreateArtist({
-								name: contents.info.upper.name,
-								source: 'bilibili',
-								remoteId: String(contents.info.upper.mid),
-							})
-							if (playlistArtistId.isErr()) throw playlistArtistId.error
+								const playlistArtistId = await artistSvc.findOrCreateArtist({
+									name: contents.info.upper.name,
+									source: 'bilibili',
+									remoteId: String(contents.info.upper.mid),
+								})
+								if (playlistArtistId.isErr()) throw playlistArtistId.error
 
-							const playlistRes = await playlistSvc.findOrCreateRemotePlaylist({
-								title: contents.info.title,
-								description: contents.info.intro,
-								coverUrl: contents.info.cover,
-								type: 'collection',
-								remoteSyncId: collectionId,
-								authorId: playlistArtistId.value.id,
-							})
-							if (playlistRes.isErr()) throw playlistRes.error
-							logger.debug('step 2: 创建 playlist 和其对应的 artist 信息完成', {
-								id: playlistRes.value.id,
-							})
-
-							const uniqueArtists = new Map<number, { name: string }>()
-							for (const media of medias) {
-								if (!uniqueArtists.has(media.upper.mid)) {
-									uniqueArtists.set(media.upper.mid, {
-										name: media.upper.name,
+								const playlistRes =
+									await playlistSvc.findOrCreateRemotePlaylist({
+										title: contents.info.title,
+										description: contents.info.intro,
+										coverUrl: contents.info.cover,
+										type: 'collection',
+										remoteSyncId: collectionId,
+										authorId: playlistArtistId.value.id,
 									})
-								}
-							}
-
-							const artistRes = await artistSvc.findOrCreateManyRemoteArtists(
-								Array.from(uniqueArtists, ([remoteId, artistInfo]) => ({
-									name: artistInfo.name,
-									source: 'bilibili',
-									remoteId: String(remoteId),
-									avatarUrl: undefined,
-								})),
-							)
-							if (artistRes.isErr()) throw artistRes.error
-							const localArtistIdMap = artistRes.value
-							logger.debug('step 3: 创建 artist 完成', {
-								uniqueCount: uniqueArtists.size,
-							})
-
-							const tracksCreateResult = await trackSvc.findOrCreateManyTracks(
-								medias.map((v) => ({
-									title: v.title,
-									source: 'bilibili',
-									bilibiliMetadata: {
-										bvid: v.bvid,
-										isMultiPage: false,
-										cid: undefined,
-										videoIsValid: true,
+								if (playlistRes.isErr()) throw playlistRes.error
+								logger.debug(
+									'step 2: 创建 playlist 和其对应的 artist 信息完成',
+									{
+										id: playlistRes.value.id,
 									},
-									coverUrl: v.cover,
-									duration: v.duration,
-									artistId: localArtistIdMap.get(String(v.upper.mid))?.id,
-								})),
-								'bilibili',
-							)
-							if (tracksCreateResult.isErr()) throw tracksCreateResult.error
-							const trackIds = Array.from(tracksCreateResult.value.values())
-							logger.debug('step 4: 创建 tracks 完成', {
-								total: trackIds.length,
-							})
+								)
 
-							// 我们不需要去更新 lastSyncedAt 字段，因为在 replacePlaylistAllTracks 中会更新
-							const replaceResult = await playlistSvc.replacePlaylistAllTracks(
-								playlistRes.value.id,
-								trackIds,
-							)
-							if (replaceResult.isErr()) {
-								throw replaceResult.error
-							}
-							logger.debug('step 5: 替换 playlist 中所有 tracks 完成')
-							logger.info('同步合集完成', {
-								remoteId: contents.info.id,
-								playlistId: playlistRes.value.id,
-							})
-							void analyticsService.logPlaylistSync(
-								'sync_bilibili',
-								'collection',
-								trackIds.length,
-							)
-							return playlistRes.value.id
+								const uniqueArtists = new Map<number, { name: string }>()
+								for (const media of medias) {
+									if (!uniqueArtists.has(media.upper.mid)) {
+										uniqueArtists.set(media.upper.mid, {
+											name: media.upper.name,
+										})
+									}
+								}
+
+								const artistRes = await artistSvc.findOrCreateManyRemoteArtists(
+									Array.from(uniqueArtists, ([remoteId, artistInfo]) => ({
+										name: artistInfo.name,
+										source: 'bilibili',
+										remoteId: String(remoteId),
+										avatarUrl: undefined,
+									})),
+								)
+								if (artistRes.isErr()) throw artistRes.error
+								const localArtistIdMap = artistRes.value
+								logger.debug('step 3: 创建 artist 完成', {
+									uniqueCount: uniqueArtists.size,
+								})
+
+								const tracksCreateResult =
+									await trackSvc.findOrCreateManyTracks(
+										medias.map((v) => ({
+											title: v.title,
+											source: 'bilibili',
+											bilibiliMetadata: {
+												bvid: v.bvid,
+												isMultiPage: false,
+												cid: undefined,
+												videoIsValid: true,
+											},
+											coverUrl: v.cover,
+											duration: v.duration,
+											artistId: localArtistIdMap.get(String(v.upper.mid))?.id,
+										})),
+										'bilibili',
+									)
+								if (tracksCreateResult.isErr()) throw tracksCreateResult.error
+								const trackIds = Array.from(tracksCreateResult.value.values())
+								logger.debug('step 4: 创建 tracks 完成', {
+									total: trackIds.length,
+								})
+
+								// 我们不需要去更新 lastSyncedAt 字段，因为在 replacePlaylistAllTracks 中会更新
+								const replaceResult =
+									await playlistSvc.replacePlaylistAllTracks(
+										playlistRes.value.id,
+										trackIds,
+									)
+								if (replaceResult.isErr()) {
+									throw replaceResult.error
+								}
+								logger.debug('step 5: 替换 playlist 中所有 tracks 完成')
+								logger.info('同步合集完成', {
+									remoteId: contents.info.id,
+									playlistId: playlistRes.value.id,
+								})
+								void analyticsService.logPlaylistSync(
+									'sync_bilibili',
+									'collection',
+									trackIds.length,
+								)
+								return playlistRes.value.id
 							})
 							await llmSmartShuffleService.indexPlaylistTracks(playlistId, {
 								sourceType: 'collection',
@@ -303,75 +311,80 @@ export class SyncBilibiliPlaylistFacade {
 					return ResultAsync.fromPromise(
 						(async () => {
 							const playlistId = await this.db.transaction(async () => {
-							const playlistSvc = this.playlistService.withDB(this.db)
-							const trackSvc = this.trackService.withDB(this.db)
-							const artistSvc = this.artistService.withDB(this.db)
+								const playlistSvc = this.playlistService.withDB(this.db)
+								const trackSvc = this.trackService.withDB(this.db)
+								const artistSvc = this.artistService.withDB(this.db)
 
-							const playlistAuthor = await artistSvc.findOrCreateArtist({
-								name: data.owner.name,
-								source: 'bilibili',
-								remoteId: String(data.owner.mid),
-								avatarUrl: data.owner.face,
-							})
-							if (playlistAuthor.isErr()) throw playlistAuthor.error
-
-							const playlistRes = await playlistSvc.findOrCreateRemotePlaylist({
-								title: data.title,
-								description: data.desc,
-								coverUrl: data.pic,
-								type: 'multi_page',
-								remoteSyncId: bv2av(bvid),
-								authorId: playlistAuthor.value.id,
-							})
-							if (playlistRes.isErr()) throw playlistRes.error
-							logger.debug('step 2: 创建 playlist 和其对应的 artist 信息完成', {
-								id: playlistRes.value.id,
-							})
-
-							const trackCreateResult = await trackSvc.findOrCreateManyTracks(
-								data.pages.map((page) => ({
-									title: page.part,
+								const playlistAuthor = await artistSvc.findOrCreateArtist({
+									name: data.owner.name,
 									source: 'bilibili',
-									bilibiliMetadata: {
-										bvid: bvid,
-										isMultiPage: true,
-										cid: page.cid,
-										videoIsValid: true,
-										mainTrackTitle: data.title,
+									remoteId: String(data.owner.mid),
+									avatarUrl: data.owner.face,
+								})
+								if (playlistAuthor.isErr()) throw playlistAuthor.error
+
+								const playlistRes =
+									await playlistSvc.findOrCreateRemotePlaylist({
+										title: data.title,
+										description: data.desc,
+										coverUrl: data.pic,
+										type: 'multi_page',
+										remoteSyncId: bv2av(bvid),
+										authorId: playlistAuthor.value.id,
+									})
+								if (playlistRes.isErr()) throw playlistRes.error
+								logger.debug(
+									'step 2: 创建 playlist 和其对应的 artist 信息完成',
+									{
+										id: playlistRes.value.id,
 									},
-									coverUrl: data.pic,
-									duration: page.duration,
-									artistId: playlistAuthor.value.id,
-								})),
-								'bilibili',
-							)
-							if (trackCreateResult.isErr()) throw trackCreateResult.error
-							const trackIds = Array.from(trackCreateResult.value.values())
-							logger.debug('step 3: 创建 tracks 完成', {
-								total: trackIds.length,
-							})
+								)
 
-							// 我们不需要去更新 lastSyncedAt 字段，因为在 replacePlaylistAllTracks 中会更新
-							const replaceResult = await playlistSvc.replacePlaylistAllTracks(
-								playlistRes.value.id,
-								trackIds,
-							)
-							if (replaceResult.isErr()) {
-								throw replaceResult.error
-							}
-							logger.debug('step 4: 替换 playlist 中所有 tracks 完成')
-							logger.info('同步合集完成', {
-								remoteId: bv2av(bvid),
-								playlistId: playlistRes.value.id,
-							})
+								const trackCreateResult = await trackSvc.findOrCreateManyTracks(
+									data.pages.map((page) => ({
+										title: page.part,
+										source: 'bilibili',
+										bilibiliMetadata: {
+											bvid: bvid,
+											isMultiPage: true,
+											cid: page.cid,
+											videoIsValid: true,
+											mainTrackTitle: data.title,
+										},
+										coverUrl: data.pic,
+										duration: page.duration,
+										artistId: playlistAuthor.value.id,
+									})),
+									'bilibili',
+								)
+								if (trackCreateResult.isErr()) throw trackCreateResult.error
+								const trackIds = Array.from(trackCreateResult.value.values())
+								logger.debug('step 3: 创建 tracks 完成', {
+									total: trackIds.length,
+								})
 
-							void analyticsService.logPlaylistSync(
-								'sync_bilibili',
-								'multi_page',
-								trackIds.length,
-							)
+								// 我们不需要去更新 lastSyncedAt 字段，因为在 replacePlaylistAllTracks 中会更新
+								const replaceResult =
+									await playlistSvc.replacePlaylistAllTracks(
+										playlistRes.value.id,
+										trackIds,
+									)
+								if (replaceResult.isErr()) {
+									throw replaceResult.error
+								}
+								logger.debug('step 4: 替换 playlist 中所有 tracks 完成')
+								logger.info('同步合集完成', {
+									remoteId: bv2av(bvid),
+									playlistId: playlistRes.value.id,
+								})
 
-							return playlistRes.value.id
+								void analyticsService.logPlaylistSync(
+									'sync_bilibili',
+									'multi_page',
+									trackIds.length,
+								)
+
+								return playlistRes.value.id
 							})
 							await llmSmartShuffleService.indexPlaylistTracks(playlistId, {
 								sourceType: 'multi_page',
@@ -506,6 +519,25 @@ export class SyncBilibiliPlaylistFacade {
 			})
 			if (bvidsToAddSet.size === 0 && bvidsToRemoveSet.size === 0) {
 				logger.info('收藏夹为空或与上次相比无变化，无需同步')
+				if (localPlaylist.value?.id) {
+					onProgress?.({
+						message: '正在创建 LLM 排序 JSON...',
+						stage: 'creating_dataset',
+					})
+					try {
+						await llmSmartShuffleDatasetService.writePlaylistDatasetFiles(
+							localPlaylist.value.id,
+							{
+								type: 'favorite',
+								sourceId: favoriteId,
+								title: bilibiliFavoriteListMetadata.info.title,
+								count: bilibiliFavoriteListMetadata.info.media_count,
+							},
+						)
+					} catch (error) {
+						logger.warning('创建 LLM 排序 JSON 失败', { error })
+					}
+				}
 				return ok(localPlaylist.value?.id)
 			}
 
@@ -778,6 +810,23 @@ export class SyncBilibiliPlaylistFacade {
 				sourceId: String(favoriteId),
 				sourceSyncedAt: new Date(),
 			})
+			onProgress?.({
+				message: '正在创建 LLM 排序 JSON...',
+				stage: 'creating_dataset',
+			})
+			try {
+				await llmSmartShuffleDatasetService.writePlaylistDatasetFiles(
+					txResult.value,
+					{
+						type: 'favorite',
+						sourceId: favoriteId,
+						title: bilibiliFavoriteListMetadata.info.title,
+						count: bilibiliFavoriteListMetadata.info.media_count,
+					},
+				)
+			} catch (error) {
+				logger.warning('创建 LLM 排序 JSON 失败', { error })
+			}
 			return ok(txResult.value)
 		} finally {
 			this.syncingIds.delete(`favorite::${favoriteId}`)

--- a/apps/mobile/src/lib/services/llmCredentialService.ts
+++ b/apps/mobile/src/lib/services/llmCredentialService.ts
@@ -1,0 +1,32 @@
+import * as SecureStore from 'expo-secure-store'
+
+import useAppStore from '@/hooks/stores/useAppStore'
+
+const LLM_API_KEY_STORAGE_KEY = 'bbplayer.llm.apiKey'
+
+export const llmCredentialService = {
+	async getApiKey() {
+		return (await SecureStore.getItemAsync(LLM_API_KEY_STORAGE_KEY)) ?? ''
+	},
+
+	async setApiKey(apiKey: string) {
+		const trimmed = apiKey.trim()
+		if (!trimmed) {
+			await SecureStore.deleteItemAsync(LLM_API_KEY_STORAGE_KEY)
+			return
+		}
+		await SecureStore.setItemAsync(LLM_API_KEY_STORAGE_KEY, trimmed)
+	},
+
+	async migrateFromPlainSettings() {
+		const settings = useAppStore.getState().settings
+		const plainApiKey = settings.llmApiKey?.trim()
+		if (!plainApiKey) return
+
+		const existing = await this.getApiKey()
+		if (!existing) {
+			await this.setApiKey(plainApiKey)
+		}
+		useAppStore.getState().setSettings({ llmApiKey: undefined })
+	},
+}

--- a/apps/mobile/src/lib/services/llmSmartShuffleDatasetService.ts
+++ b/apps/mobile/src/lib/services/llmSmartShuffleDatasetService.ts
@@ -1,0 +1,216 @@
+import { inArray } from 'drizzle-orm'
+import * as FileSystem from 'expo-file-system'
+
+import useAppStore from '@/hooks/stores/useAppStore'
+import db from '@/lib/db/db'
+import * as schema from '@/lib/db/schema'
+import { playlistService } from '@/lib/services/playlistService'
+import type { Playlist, Track } from '@/types/core/media'
+import type { TrackLlmTags } from '@/types/services/llmSmartShuffle'
+import log from '@/utils/log'
+
+const logger = log.extend('Service.LlmSmartShuffleDataset')
+
+const MAX_DATASET_TRACKS_PER_FILE = 200
+const MAX_DATASET_FILE_BYTES = 200 * 1024
+
+interface DatasetSource {
+	type: 'bilibili_favorite' | 'bilibili_collection' | 'bilibili_multi_page'
+	id: number | string
+	title?: string | null
+	count?: number | null
+	playlistId: number
+	syncedAt: string
+}
+
+interface DatasetItem {
+	trackId: number
+	uniqueKey: string
+	source: Track['source']
+	music: {
+		title: string
+		artists: string[]
+		duration: number
+		id: string
+	}
+	bilibili?: {
+		bv: string
+		title: string
+		song: string
+		duration: number
+	}
+	indexedTags?: TrackLlmTags
+	tagConfidence?: number
+	tagReason?: string | null
+	firstSeenAt: string
+}
+
+function utf8ByteLength(value: string) {
+	let length = 0
+	for (let i = 0; i < value.length; i++) {
+		const code = value.charCodeAt(i)
+		if (code < 0x80) {
+			length += 1
+		} else if (code < 0x800) {
+			length += 2
+		} else if (code >= 0xd800 && code <= 0xdbff) {
+			length += 4
+			i += 1
+		} else {
+			length += 3
+		}
+	}
+	return length
+}
+
+function sanitizeFilePart(value: string) {
+	return value.replace(/[^\w.-]+/g, '_').slice(0, 80)
+}
+
+function buildDatasetPayload(source: DatasetSource, items: DatasetItem[]) {
+	return JSON.stringify({
+		version: 2,
+		purpose: 'llm_smart_shuffle_dataset',
+		source,
+		defaultPreference: useAppStore.getState().settings.llmDefaultPreference,
+		items,
+	})
+}
+
+function chunkDatasetItems(source: DatasetSource, items: DatasetItem[]) {
+	const chunks: DatasetItem[][] = []
+	let current: DatasetItem[] = []
+
+	for (const item of items) {
+		const candidate = [...current, item]
+		const payloadBytes = utf8ByteLength(buildDatasetPayload(source, candidate))
+		const shouldSplit =
+			candidate.length > MAX_DATASET_TRACKS_PER_FILE ||
+			payloadBytes > MAX_DATASET_FILE_BYTES
+
+		if (shouldSplit && current.length > 0) {
+			chunks.push(current)
+			current = [item]
+			continue
+		}
+
+		current = candidate
+	}
+
+	if (current.length > 0) chunks.push(current)
+	return chunks
+}
+
+function toDatasetItem(
+	track: Track,
+	tagRow?: typeof schema.trackLlmTags.$inferSelect,
+): DatasetItem {
+	const base: DatasetItem = {
+		trackId: track.id,
+		uniqueKey: track.uniqueKey,
+		source: track.source,
+		music: {
+			title: track.title,
+			artists: track.artist?.name ? [track.artist.name] : [],
+			duration: track.duration,
+			id: track.uniqueKey,
+		},
+		indexedTags: tagRow?.tags,
+		tagConfidence: tagRow?.confidence,
+		tagReason: tagRow?.reason,
+		firstSeenAt: track.createdAt.toISOString(),
+	}
+
+	if (track.source !== 'bilibili') return base
+
+	return {
+		...base,
+		bilibili: {
+			bv: track.bilibiliMetadata.bvid,
+			title: track.bilibiliMetadata.mainTrackTitle ?? track.title,
+			song: track.title,
+			duration: track.duration,
+		},
+	}
+}
+
+export const llmSmartShuffleDatasetService = {
+	async writePlaylistDatasetFiles(
+		playlistId: number,
+		source: {
+			type: Playlist['type']
+			sourceId: string | number
+			title?: string | null
+			count?: number | null
+		},
+	) {
+		const tracksResult = await playlistService.getPlaylistTracks(playlistId)
+		if (tracksResult.isErr()) throw tracksResult.error
+
+		const tracks = tracksResult.value
+		const tagRows =
+			tracks.length > 0
+				? await db.query.trackLlmTags.findMany({
+						where: inArray(
+							schema.trackLlmTags.trackId,
+							tracks.map((track) => track.id),
+						),
+					})
+				: []
+		const tagsByTrackId = new Map(tagRows.map((row) => [row.trackId, row]))
+		const datasetSource: DatasetSource = {
+			type:
+				source.type === 'favorite'
+					? 'bilibili_favorite'
+					: source.type === 'collection'
+						? 'bilibili_collection'
+						: 'bilibili_multi_page',
+			id: source.sourceId,
+			title: source.title,
+			count: source.count ?? tracks.length,
+			playlistId,
+			syncedAt: new Date().toISOString(),
+		}
+		const items = tracks.map((track) =>
+			toDatasetItem(track, tagsByTrackId.get(track.id)),
+		)
+		const chunks = chunkDatasetItems(datasetSource, items)
+		const datasetDir = new FileSystem.Directory(
+			FileSystem.Paths.document,
+			'llm-datasets',
+		)
+		datasetDir.create({ intermediates: true, idempotent: true })
+
+		const prefix = `${datasetSource.type}-${sanitizeFilePart(String(datasetSource.id))}`
+		for (const entry of datasetDir.list()) {
+			if (entry instanceof FileSystem.File && entry.name.startsWith(prefix)) {
+				entry.delete()
+			}
+		}
+
+		const files: string[] = []
+		chunks.forEach((chunk, index) => {
+			const file = new FileSystem.File(
+				datasetDir,
+				`${prefix}.part-${String(index + 1).padStart(3, '0')}.json`,
+			)
+			file.write(
+				buildDatasetPayload(
+					{
+						...datasetSource,
+						count: items.length,
+					},
+					chunk,
+				),
+			)
+			files.push(file.uri)
+		})
+
+		logger.info('已写入 LLM 排序数据集 JSON', {
+			playlistId,
+			fileCount: files.length,
+			trackCount: items.length,
+		})
+		return files
+	},
+}

--- a/apps/mobile/src/lib/services/llmSmartShufflePrompts.ts
+++ b/apps/mobile/src/lib/services/llmSmartShufflePrompts.ts
@@ -1,0 +1,138 @@
+import type { Track } from '@/types/core/media'
+import type {
+	SmartShufflePreference,
+	TrackLlmTags,
+} from '@/types/services/llmSmartShuffle'
+
+export const LLM_TAG_INDEX_SYSTEM_PROMPT =
+	'你是 BBPlayer 的本地曲库标签索引器。只返回 JSON。不要返回自然语言说明。'
+
+export const LLM_PREFERENCE_SYSTEM_PROMPT =
+	'你是 BBPlayer 的听歌取向解析器。只返回 JSON，不要解释。'
+
+export const LLM_QUEUE_SORT_SYSTEM_PROMPT =
+	'你是 BBPlayer 的音乐队列排序器。只返回 JSON，不要解释。'
+
+export const LLM_QUEUE_SORT_PAYLOAD_STRATEGY =
+	'排序任务优先使用整份歌单的单个 JSON payload；当歌单超过 200 首或单个 payload 超过 200KB 时，按断点拆成多个 JSON payload 分别排序，最后在客户端合并完整队列。'
+
+export interface TrackSortPromptItem {
+	track: Track
+	tags: TrackLlmTags
+	confidence?: number
+	reason?: string | null
+}
+
+export function buildTrackTagIndexPrompt(
+	contexts: {
+		track: Track
+		sourceType?: string
+		sourceId?: string
+		sourceSyncedAt?: Date
+	}[],
+	emptyTags: TrackLlmTags,
+) {
+	return JSON.stringify({
+		task: '根据 Bilibili 音频标题和基础元数据生成结构化听歌标签。',
+		outputSchema: {
+			tracks: [
+				{
+					trackId: 'number',
+					tags: emptyTags,
+					confidence: '0 到 1',
+					reason: '简短中文原因',
+				},
+			],
+		},
+		rules: [
+			'不要臆造敏感信息。',
+			'优先识别语种、Vocaloid/中V/日V、风格、情绪、场景。',
+			'无法判断的字段返回空数组。',
+		],
+		tracks: contexts.map(({ track, sourceType, sourceId, sourceSyncedAt }) => ({
+			trackId: track.id,
+			title: track.title,
+			artist: track.artist?.name,
+			source: track.source,
+			sourceType,
+			sourceId,
+			sourceSyncedAt: sourceSyncedAt?.toISOString(),
+			firstSeenAt: track.createdAt.toISOString(),
+		})),
+	})
+}
+
+export function buildPreferencePrompt(
+	userPreference: string,
+	defaultPreference: SmartShufflePreference,
+) {
+	return JSON.stringify({
+		task: '把用户的自然语言听歌取向转换成结构化偏好。',
+		userPreference,
+		outputSchema: defaultPreference,
+	})
+}
+
+export function buildSmartQueueSortPrompt(input: {
+	userPreference: string
+	preference: SmartShufflePreference
+	items: TrackSortPromptItem[]
+	chunkIndex?: number
+	chunkCount?: number
+}) {
+	return JSON.stringify({
+		version: 2,
+		task: '根据用户听歌取向，把本次播放队列中的所有歌曲排成一个适合连续播放的顺序。',
+		payloadStrategy: LLM_QUEUE_SORT_PAYLOAD_STRATEGY,
+		chunk: {
+			index: input.chunkIndex ?? 1,
+			count: input.chunkCount ?? 1,
+			note:
+				input.chunkCount && input.chunkCount > 1
+					? '这是大歌单的一个分片，请只排序本分片内歌曲。客户端会合并所有分片。'
+					: '这是完整歌单。',
+		},
+		userPreference: input.userPreference || '未填写，按均衡智能随机排序',
+		parsedPreference: input.preference,
+		outputSchema: {
+			orderedTrackIds: ['number，必须只使用输入 items 中的 trackId'],
+			reason: '简短中文说明',
+		},
+		rules: [
+			'必须返回所有输入 trackId，不能新增、遗漏或重复。',
+			'优先满足 userPreference 和 parsedPreference。',
+			'相同歌手、相似风格或相似情绪的歌曲尽量错开，避免连续堆叠。',
+			'高 confidence 的标签更可信；低 confidence 的标签仅作弱参考。',
+			'不要按原列表机械排序，也不要按标题字母排序。',
+			'只返回 JSON 对象，不要 Markdown。',
+		],
+		items: input.items.map(({ track, tags, confidence, reason }) => {
+			const base = {
+				trackId: track.id,
+				source: track.source,
+				music: {
+					title: track.title,
+					artists: track.artist?.name ? [track.artist.name] : [],
+					duration: track.duration,
+					id: track.uniqueKey,
+				},
+				indexedTags: tags,
+				tagConfidence: confidence ?? 0,
+				tagReason: reason ?? undefined,
+				firstSeenAt: track.createdAt.toISOString(),
+			}
+
+			if (track.source !== 'bilibili') return base
+
+			return {
+				...base,
+				bilibili: {
+					bv: track.bilibiliMetadata.bvid,
+					title: track.bilibiliMetadata.mainTrackTitle ?? track.title,
+					song: track.title,
+					duration: track.duration,
+				},
+			}
+		}),
+	})
+}

--- a/apps/mobile/src/lib/services/llmSmartShuffleService.ts
+++ b/apps/mobile/src/lib/services/llmSmartShuffleService.ts
@@ -1,0 +1,440 @@
+import { inArray, sql } from 'drizzle-orm'
+
+import useAppStore from '@/hooks/stores/useAppStore'
+import db from '@/lib/db/db'
+import * as schema from '@/lib/db/schema'
+import { playlistService } from '@/lib/services/playlistService'
+import type { Playlist, Track } from '@/types/core/media'
+import type {
+	SmartQueueOptions,
+	SmartShufflePreference,
+	TrackIndexContext,
+	TrackLlmTags,
+	TrackTagIndex,
+} from '@/types/services/llmSmartShuffle'
+import log from '@/utils/log'
+
+const logger = log.extend('Service.LlmSmartShuffle')
+
+const EMPTY_TAGS: TrackLlmTags = {
+	language: [],
+	vocalType: [],
+	genre: [],
+	mood: [],
+	scene: [],
+	timePreference: [],
+}
+
+function createEmptyTags(): TrackLlmTags {
+	return {
+		language: [],
+		vocalType: [],
+		genre: [],
+		mood: [],
+		scene: [],
+		timePreference: [],
+	}
+}
+
+const DEFAULT_PREFERENCE: SmartShufflePreference = {
+	preferredTags: [],
+	downrankTags: [],
+	timeBias: 'balanced',
+	explorationLevel: 'balanced',
+	repeatAvoidance: true,
+	temporary: false,
+}
+
+interface OpenAIChatCompletionResponse {
+	choices?: {
+		message?: {
+			content?: string
+		}
+	}[]
+}
+
+function normalizeBaseUrl(baseUrl: string) {
+	return baseUrl.trim().replace(/\/+$/, '')
+}
+
+function asStringArray(value: unknown): string[] {
+	if (!Array.isArray(value)) return []
+	return value
+		.filter((item): item is string => typeof item === 'string')
+		.map((item) => item.trim())
+		.filter(Boolean)
+}
+
+function normalizeTags(value: unknown): TrackLlmTags {
+	if (!value || typeof value !== 'object') return createEmptyTags()
+	const tags = value as Partial<Record<keyof TrackLlmTags, unknown>>
+	return {
+		language: asStringArray(tags.language),
+		vocalType: asStringArray(tags.vocalType),
+		genre: asStringArray(tags.genre),
+		mood: asStringArray(tags.mood),
+		scene: asStringArray(tags.scene),
+		timePreference: asStringArray(tags.timePreference),
+	}
+}
+
+function parseJsonObject<T>(content: string): T {
+	try {
+		return JSON.parse(content) as T
+	} catch {
+		const match = content.match(/\{[\s\S]*\}/)
+		if (!match) throw new Error('LLM 没有返回 JSON 对象')
+		return JSON.parse(match[0]) as T
+	}
+}
+
+function allTags(tags: TrackLlmTags) {
+	return [
+		...tags.language,
+		...tags.vocalType,
+		...tags.genre,
+		...tags.mood,
+		...tags.scene,
+		...tags.timePreference,
+	].map((tag) => tag.toLowerCase())
+}
+
+function getLocalTitleTags(track: Track): TrackLlmTags {
+	const text = `${track.title} ${track.artist?.name ?? ''}`.toLowerCase()
+	const tags = createEmptyTags()
+
+	if (/中v|中文vocaloid|洛天依|乐正绫|言和|星尘|心华/.test(text)) {
+		tags.language.push('中文')
+		tags.vocalType.push('中V')
+	}
+	if (/vocaloid|初音|miku|镜音|巡音|gumi/.test(text)) {
+		tags.vocalType.push('Vocaloid')
+	}
+	if (/日v|日语|jpop|jp|初音|miku/.test(text)) {
+		tags.language.push('日文')
+	}
+	if (/古风|国风/.test(text)) tags.genre.push('古风')
+	if (/电音|电子|edm|remix/.test(text)) tags.genre.push('电子')
+	if (/摇滚|rock/.test(text)) tags.genre.push('摇滚')
+	if (/治愈|安静|温柔|轻/.test(text)) tags.mood.push('治愈')
+	if (/燃|热血|快|high/.test(text)) tags.mood.push('燃')
+	if (/夜|晚安|睡/.test(text)) tags.scene.push('夜晚')
+
+	return tags
+}
+
+function parsePreferenceLocally(prompt: string): SmartShufflePreference {
+	const value = prompt.toLowerCase()
+	const preferredTags: string[] = []
+	const downrankTags: string[] = []
+
+	if (/中v|中文v|洛天依|乐正绫|言和/.test(value)) preferredTags.push('中V')
+	if (/vocaloid|术力口|初音|miku/.test(value)) preferredTags.push('Vocaloid')
+	if (/最近|新收藏|刚收藏|新加/.test(value)) preferredTags.push('最近新增')
+	if (/老歌|老收藏|回顾/.test(value)) preferredTags.push('老收藏')
+	if (/燃|热血|快/.test(value)) preferredTags.push('燃')
+	if (/治愈|安静|放松|睡/.test(value)) preferredTags.push('治愈')
+	if (/学习|工作/.test(value)) preferredTags.push('工作')
+	if (/别太吵|少听吵|不吵/.test(value)) downrankTags.push('吵闹', '燃')
+	if (/少重复|别重复|不重复/.test(value)) {
+		return { ...DEFAULT_PREFERENCE, preferredTags, downrankTags }
+	}
+
+	return {
+		...DEFAULT_PREFERENCE,
+		preferredTags,
+		downrankTags,
+		timeBias: /最近|新收藏|刚收藏|新加/.test(value)
+			? 'recent'
+			: /老歌|老收藏|回顾/.test(value)
+				? 'old'
+				: 'balanced',
+		explorationLevel: /冷门|探索|随机一点/.test(value)
+			? 'exploratory'
+			: 'balanced',
+	}
+}
+
+function stableShuffle<T>(items: T[]) {
+	const array = [...items]
+	for (let i = array.length - 1; i > 0; i--) {
+		const j = Math.floor(Math.random() * (i + 1))
+		const temp = array[i]
+		array[i] = array[j]
+		array[j] = temp
+	}
+	return array
+}
+
+export class LlmSmartShuffleService {
+	private isConfigured() {
+		const settings = useAppStore.getState().settings
+		return (
+			settings.enableLlmTagging &&
+			settings.allowLlmMetadataUpload &&
+			settings.llmBaseUrl.trim().length > 0 &&
+			settings.llmModel.trim().length > 0
+		)
+	}
+
+	private async callJson<T>(system: string, user: string): Promise<T> {
+		const settings = useAppStore.getState().settings
+		const url = `${normalizeBaseUrl(settings.llmBaseUrl)}/chat/completions`
+		const headers: Record<string, string> = {
+			'Content-Type': 'application/json',
+		}
+		if (settings.llmApiKey.trim()) {
+			headers.Authorization = `Bearer ${settings.llmApiKey.trim()}`
+		}
+
+		const response = await fetch(url, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				model: settings.llmModel.trim(),
+				temperature: 0.1,
+				response_format: { type: 'json_object' },
+				messages: [
+					{ role: 'system', content: system },
+					{ role: 'user', content: user },
+				],
+			}),
+		})
+
+		if (!response.ok) {
+			throw new Error(`LLM API 请求失败：${response.status}`)
+		}
+
+		const data = (await response.json()) as OpenAIChatCompletionResponse
+		const content = data.choices?.[0]?.message?.content
+		if (!content) {
+			throw new Error('LLM API 没有返回内容')
+		}
+		return parseJsonObject<T>(content)
+	}
+
+	async indexTracks(contexts: TrackIndexContext[]) {
+		if (!this.isConfigured() || contexts.length === 0) return
+		for (let i = 0; i < contexts.length; i += 25) {
+			await this.indexTrackBatch(contexts.slice(i, i + 25))
+		}
+	}
+
+	private async indexTrackBatch(contexts: TrackIndexContext[]) {
+		const settings = useAppStore.getState().settings
+
+		const response = await this.callJson<{ tracks?: unknown[] }>(
+			'你是 BBPlayer 的本地曲库标签索引器。只返回 JSON。不要返回自然语言说明。',
+			JSON.stringify({
+				task: '根据 Bilibili 音频标题和基础元数据生成结构化听歌标签。',
+				outputSchema: {
+					tracks: [
+						{
+							trackId: 'number',
+							tags: EMPTY_TAGS,
+							confidence: '0 到 1',
+							reason: '简短中文原因',
+						},
+					],
+				},
+				rules: [
+					'不要臆造敏感信息。',
+					'优先识别语种、Vocaloid/中V/日V、风格、情绪、场景。',
+					'无法判断的字段返回空数组。',
+				],
+				tracks: contexts.map(({ track, sourceType, sourceId, sourceSyncedAt }) => ({
+					trackId: track.id,
+					title: track.title,
+					artist: track.artist?.name,
+					source: track.source,
+					sourceType,
+					sourceId,
+					sourceSyncedAt: sourceSyncedAt?.toISOString(),
+					firstSeenAt: track.createdAt.toISOString(),
+				})),
+			}),
+		)
+
+		const indexes: TrackTagIndex[] = (response.tracks ?? [])
+			.map((item) => {
+				if (!item || typeof item !== 'object') return null
+				const row = item as Record<string, unknown>
+				const trackId = Number(row.trackId)
+				if (!Number.isFinite(trackId)) return null
+				return {
+					trackId,
+					tags: normalizeTags(row.tags),
+					confidence:
+						typeof row.confidence === 'number'
+							? Math.max(0, Math.min(1, row.confidence))
+							: 0,
+					reason: typeof row.reason === 'string' ? row.reason : undefined,
+				}
+			})
+			.filter((item): item is TrackTagIndex => item !== null)
+
+		if (indexes.length === 0) return
+
+		const contextById = new Map(contexts.map((item) => [item.track.id, item]))
+		await db
+			.insert(schema.trackLlmTags)
+			.values(
+				indexes.map((index) => {
+					const context = contextById.get(index.trackId)
+					return {
+						trackId: index.trackId,
+						tags: index.tags,
+						confidence: index.confidence,
+						reason: index.reason,
+						model: settings.llmModel.trim(),
+						sourceType: context?.sourceType,
+						sourceId: context?.sourceId,
+						sourceSyncedAt: context?.sourceSyncedAt,
+						indexedAt: new Date(),
+					}
+				}),
+			)
+			.onConflictDoUpdate({
+				target: schema.trackLlmTags.trackId,
+				set: {
+					tags: sql`excluded.tags`,
+					confidence: sql`excluded.confidence`,
+					reason: sql`excluded.reason`,
+					model: sql`excluded.model`,
+					sourceType: sql`excluded.source_type`,
+					sourceId: sql`excluded.source_id`,
+					sourceSyncedAt: sql`excluded.source_synced_at`,
+					indexedAt: new Date(),
+				},
+			})
+	}
+
+	async indexPlaylistTracks(
+		playlistId: number,
+		options?: {
+			sourceType?: Playlist['type']
+			sourceId?: string
+			sourceSyncedAt?: Date
+		},
+	) {
+		try {
+			const tracksResult = await playlistService.getPlaylistTracks(playlistId)
+			if (tracksResult.isErr()) {
+				logger.warning('获取歌单歌曲用于 LLM 索引失败', tracksResult.error)
+				return
+			}
+			await this.indexTracks(
+				tracksResult.value.map((track) => ({
+					track,
+					sourceType: options?.sourceType,
+					sourceId: options?.sourceId,
+					sourceSyncedAt: options?.sourceSyncedAt,
+				})),
+			)
+		} catch (error) {
+			logger.warning('LLM 标签索引失败', { error })
+		}
+	}
+
+	async parsePreference(prompt: string): Promise<SmartShufflePreference> {
+		const trimmed = prompt.trim()
+		if (!trimmed || !this.isConfigured()) {
+			return parsePreferenceLocally(trimmed)
+		}
+
+		try {
+			const response = await this.callJson<Partial<SmartShufflePreference>>(
+				'你是 BBPlayer 的听歌取向解析器。只返回 JSON，不要解释。',
+				JSON.stringify({
+					task: '把用户的自然语言听歌取向转换成结构化偏好。',
+					userPreference: trimmed,
+					outputSchema: DEFAULT_PREFERENCE,
+				}),
+			)
+			return {
+				preferredTags: asStringArray(response.preferredTags),
+				downrankTags: asStringArray(response.downrankTags),
+				timeBias:
+					response.timeBias === 'recent' ||
+					response.timeBias === 'old' ||
+					response.timeBias === 'balanced'
+						? response.timeBias
+						: 'balanced',
+				explorationLevel:
+					response.explorationLevel === 'conservative' ||
+					response.explorationLevel === 'balanced' ||
+					response.explorationLevel === 'exploratory'
+						? response.explorationLevel
+						: 'balanced',
+				repeatAvoidance: response.repeatAvoidance ?? true,
+				temporary: response.temporary ?? true,
+			}
+		} catch (error) {
+			logger.warning('LLM 解析偏好失败，使用本地关键词规则', { error })
+			return parsePreferenceLocally(trimmed)
+		}
+	}
+
+	async createSmartQueue(
+		tracks: Track[],
+		options?: SmartQueueOptions,
+	): Promise<Track[]> {
+		if (tracks.length <= 1) return tracks
+
+		const prompt =
+			options?.prompt?.trim() || options?.defaultPreference?.trim() || ''
+		const preference = await this.parsePreference(prompt)
+		const tagRows = await db.query.trackLlmTags.findMany({
+			where: inArray(
+				schema.trackLlmTags.trackId,
+				tracks.map((track) => track.id),
+			),
+		})
+		const tagsByTrackId = new Map(tagRows.map((row) => [row.trackId, row]))
+
+		const now = Date.now()
+		const preferredTags = preference.preferredTags.map((tag) =>
+			tag.toLowerCase(),
+		)
+		const downrankTags = preference.downrankTags.map((tag) => tag.toLowerCase())
+
+		return stableShuffle(tracks)
+			.map((track) => {
+				const row = tagsByTrackId.get(track.id)
+				const tags = row?.tags ?? getLocalTitleTags(track)
+				const trackTags = allTags(tags)
+				let score = 1
+
+				for (const tag of preferredTags) {
+					if (trackTags.some((item) => item.includes(tag))) score += 3
+				}
+				for (const tag of downrankTags) {
+					if (trackTags.some((item) => item.includes(tag))) score -= 2
+				}
+
+				const firstSeenAgeDays = Math.max(
+					0,
+					(now - track.createdAt.getTime()) / 86_400_000,
+				)
+				if (preference.timeBias === 'recent') {
+					score += Math.max(0, 4 - firstSeenAgeDays / 7)
+				} else if (preference.timeBias === 'old') {
+					score += Math.min(4, firstSeenAgeDays / 30)
+				}
+
+				if (preference.explorationLevel === 'exploratory') {
+					score += Math.random() * 3
+				} else if (preference.explorationLevel === 'conservative') {
+					score += row?.confidence ?? 0
+				} else {
+					score += Math.random()
+				}
+
+				return { track, score }
+			})
+			.sort((a, b) => b.score - a.score)
+			.map((item) => item.track)
+	}
+}
+
+export const llmSmartShuffleService = new LlmSmartShuffleService()

--- a/apps/mobile/src/lib/services/llmSmartShuffleService.ts
+++ b/apps/mobile/src/lib/services/llmSmartShuffleService.ts
@@ -158,26 +158,178 @@ function allTags(tags: TrackLlmTags) {
 	].map((tag) => tag.toLowerCase())
 }
 
+type TrackLlmTagCategory = keyof TrackLlmTags
+
+interface LocalTitleTagRule {
+	category: TrackLlmTagCategory
+	tag: string
+	pattern: RegExp
+}
+
+const LOCAL_TITLE_TAG_RULES: LocalTitleTagRule[] = [
+	{
+		category: 'language',
+		tag: '中文',
+		pattern:
+			/中文|国语|华语|普通话|中配|洛天依|乐正绫|言和|星尘|心华|诗岸|海伊|苍穹|赤羽|墨清弦|徵羽摩柯|乐正龙牙|五维介质|ace虚拟歌姬/i,
+	},
+	{
+		category: 'language',
+		tag: '日文',
+		pattern:
+			/日语|日文|日本語|j-?pop|anime|アニメ|初音|镜音|鏡音|巡音|重音|miku|rin|len|luka|teto|gumi|kafu|可不/i,
+	},
+	{
+		category: 'language',
+		tag: '英文',
+		pattern: /英文|英语|欧美|\b(english|eng|en|us|uk)\b/i,
+	},
+	{
+		category: 'vocalType',
+		tag: '中V',
+		pattern:
+			/中v|中文vocaloid|洛天依|乐正绫|言和|星尘|心华|诗岸|海伊|苍穹|赤羽|墨清弦|徵羽摩柯|乐正龙牙|五维介质|ace虚拟歌姬/i,
+	},
+	{
+		category: 'vocalType',
+		tag: '日V',
+		pattern:
+			/日v|初音|镜音|鏡音|巡音|重音|miku|rin|len|luka|teto|gumi|kafu|可不|flower|ia\b/i,
+	},
+	{
+		category: 'vocalType',
+		tag: 'Vocaloid',
+		pattern:
+			/vocaloid|术力口|ボカロ|初音|镜音|鏡音|巡音|重音|miku|rin|len|luka|teto|gumi|kafu|可不|flower|ia\b/i,
+	},
+	{
+		category: 'vocalType',
+		tag: '翻唱',
+		pattern: /翻唱|cover|歌ってみた|试唱|remake/i,
+	},
+	{
+		category: 'vocalType',
+		tag: '合唱',
+		pattern: /合唱|对唱|chorus|duet|feat\.?|ft\./i,
+	},
+	{
+		category: 'vocalType',
+		tag: '纯音乐',
+		pattern: /纯音乐|instrumental|伴奏|off vocal|karaoke|\bbgm\b/i,
+	},
+	{ category: 'genre', tag: '古风', pattern: /古风|古韵|戏腔/i },
+	{
+		category: 'genre',
+		tag: '国风',
+		pattern: /国风|中国风|民乐|笛子|古筝|二胡/i,
+	},
+	{
+		category: 'genre',
+		tag: '电子',
+		pattern:
+			/电音|电子|edm|future bass|dubstep|synthwave|trance|house|techno|hardstyle/i,
+	},
+	{
+		category: 'genre',
+		tag: '摇滚',
+		pattern: /摇滚|rock|punk|alternative|后摇|post-?rock/i,
+	},
+	{ category: 'genre', tag: '金属', pattern: /金属|metal|metalcore/i },
+	{
+		category: 'genre',
+		tag: '流行',
+		pattern: /流行|pop|j-?pop|k-?pop|city pop/i,
+	},
+	{ category: 'genre', tag: '说唱', pattern: /说唱|rap|hip-?hop|trap/i },
+	{ category: 'genre', tag: '爵士', pattern: /爵士|jazz|swing|blues/i },
+	{ category: 'genre', tag: '民谣', pattern: /民谣|folk|acoustic|吉他弹唱/i },
+	{ category: 'genre', tag: '钢琴', pattern: /钢琴|piano/i },
+	{ category: 'genre', tag: '交响', pattern: /交响|管弦|orchestra|symphony/i },
+	{ category: 'genre', tag: 'Lo-fi', pattern: /lo-?fi|chillhop/i },
+	{
+		category: 'genre',
+		tag: 'ACG',
+		pattern: /acg|anime|アニメ|二次元|番剧|op\b|ed\b/i,
+	},
+	{
+		category: 'genre',
+		tag: '游戏音乐',
+		pattern: /游戏|game|ost|原声|soundtrack/i,
+	},
+	{
+		category: 'mood',
+		tag: '治愈',
+		pattern: /治愈|疗愈|healing|放松|舒缓|安心/i,
+	},
+	{ category: 'mood', tag: '温柔', pattern: /温柔|柔和|轻柔|soft|gentle/i },
+	{ category: 'mood', tag: '安静', pattern: /安静|静谧|宁静|quiet|calm/i },
+	{ category: 'mood', tag: '燃', pattern: /燃|热血|高燃|战斗|battle|激昂/i },
+	{
+		category: 'mood',
+		tag: '高能',
+		pattern: /高能|炸裂|爆裂|狂气|hardcore|high energy/i,
+	},
+	{ category: 'mood', tag: '悲伤', pattern: /悲伤|伤感|失恋|泪|sad|cry/i },
+	{ category: 'mood', tag: '致郁', pattern: /致郁|压抑|抑郁|黑暗|dark/i },
+	{ category: 'mood', tag: '甜', pattern: /甜|甜蜜|恋爱|love|可爱|萌/i },
+	{
+		category: 'mood',
+		tag: '梦幻',
+		pattern: /梦幻|空灵|幻想|fantasy|ethereal/i,
+	},
+	{ category: 'mood', tag: '怀旧', pattern: /怀旧|复古|retro|nostalgic/i },
+	{ category: 'mood', tag: '史诗', pattern: /史诗|epic|恢弘|宏大/i },
+	{
+		category: 'scene',
+		tag: '夜晚',
+		pattern: /夜|夜晚|深夜|午夜|晚安|moon|night/i,
+	},
+	{ category: 'scene', tag: '睡前', pattern: /睡前|助眠|催眠|入眠|sleep|眠/i },
+	{ category: 'scene', tag: '学习', pattern: /学习|自习|专注|study|focus/i },
+	{
+		category: 'scene',
+		tag: '工作',
+		pattern: /工作|办公|效率|work|coding|编程/i,
+	},
+	{ category: 'scene', tag: '通勤', pattern: /通勤|地铁|公交|路上|commute/i },
+	{
+		category: 'scene',
+		tag: '运动',
+		pattern: /运动|健身|跑步|workout|running/i,
+	},
+	{ category: 'scene', tag: '驾驶', pattern: /驾驶|开车|车载|drive|driving/i },
+	{ category: 'scene', tag: '雨天', pattern: /雨|雨天|rain/i },
+	{ category: 'scene', tag: '派对', pattern: /派对|party|club|蹦迪/i },
+	{
+		category: 'timePreference',
+		tag: '经典老歌',
+		pattern: /经典|老歌|回忆|怀旧|80s|90s|00s|昭和|平成/i,
+	},
+	{
+		category: 'timePreference',
+		tag: '新歌',
+		pattern: /新歌|新曲|新作|202[3-9]|20[3-9]\d/i,
+	},
+]
+
+function addLocalTag(
+	tags: TrackLlmTags,
+	category: TrackLlmTagCategory,
+	tag: string,
+) {
+	const values = tags[category]
+	if (!values.includes(tag)) values.push(tag)
+}
+
 function getLocalTitleTags(track: Track): TrackLlmTags {
 	const text = `${track.title} ${track.artist?.name ?? ''}`.toLowerCase()
 	const tags = createEmptyTags()
 
-	if (/中v|中文vocaloid|洛天依|乐正绫|言和|星尘|心华/.test(text)) {
-		tags.language.push('中文')
-		tags.vocalType.push('中V')
+	for (const rule of LOCAL_TITLE_TAG_RULES) {
+		if (rule.pattern.test(text)) {
+			addLocalTag(tags, rule.category, rule.tag)
+		}
 	}
-	if (/vocaloid|初音|miku|镜音|巡音|gumi/.test(text)) {
-		tags.vocalType.push('Vocaloid')
-	}
-	if (/日v|日语|jpop|jp|初音|miku/.test(text)) {
-		tags.language.push('日文')
-	}
-	if (/古风|国风/.test(text)) tags.genre.push('古风')
-	if (/电音|电子|edm|remix/.test(text)) tags.genre.push('电子')
-	if (/摇滚|rock/.test(text)) tags.genre.push('摇滚')
-	if (/治愈|安静|温柔|轻/.test(text)) tags.mood.push('治愈')
-	if (/燃|热血|快|high/.test(text)) tags.mood.push('燃')
-	if (/夜|晚安|睡/.test(text)) tags.scene.push('夜晚')
 
 	return tags
 }

--- a/apps/mobile/src/lib/services/llmSmartShuffleService.ts
+++ b/apps/mobile/src/lib/services/llmSmartShuffleService.ts
@@ -4,6 +4,15 @@ import useAppStore from '@/hooks/stores/useAppStore'
 import db from '@/lib/db/db'
 import * as schema from '@/lib/db/schema'
 import { llmCredentialService } from '@/lib/services/llmCredentialService'
+import {
+	LLM_PREFERENCE_SYSTEM_PROMPT,
+	LLM_QUEUE_SORT_SYSTEM_PROMPT,
+	LLM_TAG_INDEX_SYSTEM_PROMPT,
+	buildPreferencePrompt,
+	buildSmartQueueSortPrompt,
+	buildTrackTagIndexPrompt,
+} from '@/lib/services/llmSmartShufflePrompts'
+import type { TrackSortPromptItem } from '@/lib/services/llmSmartShufflePrompts'
 import { playlistService } from '@/lib/services/playlistService'
 import type { Playlist, Track } from '@/types/core/media'
 import type {
@@ -16,6 +25,9 @@ import type {
 import log from '@/utils/log'
 
 const logger = log.extend('Service.LlmSmartShuffle')
+
+const MAX_LLM_SORT_TRACKS_PER_PAYLOAD = 200
+const MAX_LLM_SORT_PAYLOAD_BYTES = 200 * 1024
 
 const EMPTY_TAGS: TrackLlmTags = {
 	language: [],
@@ -52,6 +64,13 @@ interface OpenAIChatCompletionResponse {
 			content?: string
 		}
 	}[]
+}
+
+interface TrackLlmTagRow {
+	trackId: number
+	tags: TrackLlmTags
+	confidence: number
+	reason: string | null
 }
 
 function normalizeBaseUrl(baseUrl: string) {
@@ -167,6 +186,60 @@ function stableShuffle<T>(items: T[]) {
 	return array
 }
 
+function asNumberArray(value: unknown): number[] {
+	if (!Array.isArray(value)) return []
+	return value
+		.map((item) => Number(item))
+		.filter((item) => Number.isInteger(item))
+}
+
+function extractOrderedTrackIds(response: {
+	orderedTrackIds?: unknown
+	trackIds?: unknown
+	tracks?: unknown
+}) {
+	const direct = asNumberArray(response.orderedTrackIds)
+	if (direct.length > 0) return direct
+
+	const trackIds = asNumberArray(response.trackIds)
+	if (trackIds.length > 0) return trackIds
+
+	if (!Array.isArray(response.tracks)) return []
+	return response.tracks
+		.map((item) => {
+			if (typeof item === 'number' || typeof item === 'string')
+				return Number(item)
+			if (!item || typeof item !== 'object') return NaN
+			return Number((item as Record<string, unknown>).trackId)
+		})
+		.filter((item) => Number.isInteger(item))
+}
+
+function getTrackTags(
+	track: Track,
+	tagsByTrackId: Map<number, TrackLlmTagRow>,
+) {
+	return tagsByTrackId.get(track.id)?.tags ?? getLocalTitleTags(track)
+}
+
+function utf8ByteLength(value: string) {
+	let length = 0
+	for (let i = 0; i < value.length; i++) {
+		const code = value.charCodeAt(i)
+		if (code < 0x80) {
+			length += 1
+		} else if (code < 0x800) {
+			length += 2
+		} else if (code >= 0xd800 && code <= 0xdbff) {
+			length += 4
+			i += 1
+		} else {
+			length += 3
+		}
+	}
+	return length
+}
+
 export class LlmSmartShuffleService {
 	private isConfigured() {
 		const settings = useAppStore.getState().settings
@@ -227,37 +300,8 @@ export class LlmSmartShuffleService {
 		const settings = useAppStore.getState().settings
 
 		const response = await this.callJson<{ tracks?: unknown[] }>(
-			'你是 BBPlayer 的本地曲库标签索引器。只返回 JSON。不要返回自然语言说明。',
-			JSON.stringify({
-				task: '根据 Bilibili 音频标题和基础元数据生成结构化听歌标签。',
-				outputSchema: {
-					tracks: [
-						{
-							trackId: 'number',
-							tags: EMPTY_TAGS,
-							confidence: '0 到 1',
-							reason: '简短中文原因',
-						},
-					],
-				},
-				rules: [
-					'不要臆造敏感信息。',
-					'优先识别语种、Vocaloid/中V/日V、风格、情绪、场景。',
-					'无法判断的字段返回空数组。',
-				],
-				tracks: contexts.map(
-					({ track, sourceType, sourceId, sourceSyncedAt }) => ({
-						trackId: track.id,
-						title: track.title,
-						artist: track.artist?.name,
-						source: track.source,
-						sourceType,
-						sourceId,
-						sourceSyncedAt: sourceSyncedAt?.toISOString(),
-						firstSeenAt: track.createdAt.toISOString(),
-					}),
-				),
-			}),
+			LLM_TAG_INDEX_SYSTEM_PROMPT,
+			buildTrackTagIndexPrompt(contexts, EMPTY_TAGS),
 		)
 
 		const indexes = (response.tracks ?? [])
@@ -350,12 +394,8 @@ export class LlmSmartShuffleService {
 
 		try {
 			const response = await this.callJson<Partial<SmartShufflePreference>>(
-				'你是 BBPlayer 的听歌取向解析器。只返回 JSON，不要解释。',
-				JSON.stringify({
-					task: '把用户的自然语言听歌取向转换成结构化偏好。',
-					userPreference: trimmed,
-					outputSchema: DEFAULT_PREFERENCE,
-				}),
+				LLM_PREFERENCE_SYSTEM_PROMPT,
+				buildPreferencePrompt(trimmed, DEFAULT_PREFERENCE),
 			)
 			return {
 				preferredTags: asStringArray(response.preferredTags),
@@ -396,8 +436,210 @@ export class LlmSmartShuffleService {
 				tracks.map((track) => track.id),
 			),
 		})
-		const tagsByTrackId = new Map(tagRows.map((row) => [row.trackId, row]))
+		const tagsByTrackId = new Map<number, TrackLlmTagRow>(
+			tagRows.map((row) => [row.trackId, row]),
+		)
 
+		const llmSortedQueue = await this.createLlmSortedQueue(
+			tracks,
+			prompt,
+			preference,
+			tagsByTrackId,
+		)
+		if (llmSortedQueue) return llmSortedQueue
+
+		return this.createLocalScoredQueue(tracks, preference, tagsByTrackId)
+	}
+
+	private async createLlmSortedQueue(
+		tracks: Track[],
+		prompt: string,
+		preference: SmartShufflePreference,
+		tagsByTrackId: Map<number, TrackLlmTagRow>,
+	) {
+		if (!this.isConfigured()) return null
+
+		try {
+			const fallbackOrder = this.createLocalScoredQueue(
+				tracks,
+				preference,
+				tagsByTrackId,
+			)
+			const items = tracks.map((track) =>
+				this.createSortPromptItem(track, tagsByTrackId),
+			)
+			const chunks = this.createSortPayloadChunks(prompt, preference, items)
+			const chunkOrders = await Promise.all(
+				chunks.map(async (chunk, index) => {
+					const response = await this.callJson<{
+						orderedTrackIds?: unknown
+						trackIds?: unknown
+						tracks?: unknown
+					}>(
+						LLM_QUEUE_SORT_SYSTEM_PROMPT,
+						buildSmartQueueSortPrompt({
+							userPreference: prompt,
+							preference,
+							items: chunk,
+							chunkIndex: index + 1,
+							chunkCount: chunks.length,
+						}),
+					)
+					const chunkTrackIds = new Set(chunk.map((item) => item.track.id))
+					const chunkFallback = fallbackOrder.filter((track) =>
+						chunkTrackIds.has(track.id),
+					)
+					return this.mergeLlmOrderWithFallback(
+						chunk.map((item) => item.track),
+						extractOrderedTrackIds(response),
+						chunkFallback,
+					)
+				}),
+			)
+
+			if (chunkOrders.some((chunk) => chunk === null)) return null
+
+			const orderedTrackIds =
+				chunkOrders.length === 1
+					? (chunkOrders[0]?.map((track) => track.id) ?? [])
+					: this.mergeChunkOrders(
+							chunkOrders.filter((chunk): chunk is Track[] => chunk !== null),
+							fallbackOrder,
+						).map((track) => track.id)
+
+			return this.mergeLlmOrderWithFallback(
+				tracks,
+				orderedTrackIds,
+				fallbackOrder,
+			)
+		} catch (error) {
+			logger.warning('LLM 直接排序失败，使用本地标签打分', { error })
+			return null
+		}
+	}
+
+	private createSortPromptItem(
+		track: Track,
+		tagsByTrackId: Map<number, TrackLlmTagRow>,
+	): TrackSortPromptItem {
+		const row = tagsByTrackId.get(track.id)
+		return {
+			track,
+			tags: getTrackTags(track, tagsByTrackId),
+			confidence: row?.confidence,
+			reason: row?.reason,
+		}
+	}
+
+	private createSortPayloadChunks(
+		prompt: string,
+		preference: SmartShufflePreference,
+		items: TrackSortPromptItem[],
+	) {
+		const chunks: TrackSortPromptItem[][] = []
+		let current: TrackSortPromptItem[] = []
+
+		for (const item of items) {
+			const candidate = [...current, item]
+			const payloadBytes = utf8ByteLength(
+				buildSmartQueueSortPrompt({
+					userPreference: prompt,
+					preference,
+					items: candidate,
+				}),
+			)
+			const shouldSplit =
+				candidate.length > MAX_LLM_SORT_TRACKS_PER_PAYLOAD ||
+				payloadBytes > MAX_LLM_SORT_PAYLOAD_BYTES
+
+			if (shouldSplit && current.length > 0) {
+				chunks.push(current)
+				current = [item]
+				continue
+			}
+
+			current = candidate
+		}
+
+		if (current.length > 0) chunks.push(current)
+		if (chunks.length > 1) {
+			logger.info('LLM 排序 payload 已按上下文限制分片', {
+				chunkCount: chunks.length,
+				totalTracks: items.length,
+			})
+		}
+		return chunks
+	}
+
+	private mergeChunkOrders(chunkOrders: Track[][], fallbackOrder: Track[]) {
+		const fallbackRank = new Map(
+			fallbackOrder.map((track, index) => [track.id, index]),
+		)
+		const queues = [...chunkOrders].sort((left, right) => {
+			const leftRank =
+				fallbackRank.get(left[0]?.id ?? -1) ?? Number.MAX_SAFE_INTEGER
+			const rightRank =
+				fallbackRank.get(right[0]?.id ?? -1) ?? Number.MAX_SAFE_INTEGER
+			return leftRank - rightRank
+		})
+		const merged: Track[] = []
+		let hasRemaining = true
+
+		while (hasRemaining) {
+			hasRemaining = false
+			queues.sort((left, right) => {
+				const leftRank =
+					fallbackRank.get(left[0]?.id ?? -1) ?? Number.MAX_SAFE_INTEGER
+				const rightRank =
+					fallbackRank.get(right[0]?.id ?? -1) ?? Number.MAX_SAFE_INTEGER
+				return leftRank - rightRank
+			})
+
+			for (const queue of queues) {
+				const next = queue.shift()
+				if (!next) continue
+				merged.push(next)
+				hasRemaining = true
+			}
+		}
+
+		return merged
+	}
+
+	private mergeLlmOrderWithFallback(
+		tracks: Track[],
+		orderedTrackIds: number[],
+		fallbackOrder: Track[],
+	) {
+		if (orderedTrackIds.length === 0) {
+			return fallbackOrder.length > 0 ? fallbackOrder : null
+		}
+
+		const tracksById = new Map(tracks.map((track) => [track.id, track]))
+		const seen = new Set<number>()
+		const sorted: Track[] = []
+
+		for (const trackId of orderedTrackIds) {
+			const track = tracksById.get(trackId)
+			if (!track || seen.has(trackId)) continue
+			seen.add(trackId)
+			sorted.push(track)
+		}
+
+		for (const track of fallbackOrder) {
+			if (seen.has(track.id)) continue
+			seen.add(track.id)
+			sorted.push(track)
+		}
+
+		return sorted.length > 0 ? sorted : null
+	}
+
+	private createLocalScoredQueue(
+		tracks: Track[],
+		preference: SmartShufflePreference,
+		tagsByTrackId: Map<number, TrackLlmTagRow>,
+	): Track[] {
 		const now = Date.now()
 		const preferredTags = preference.preferredTags.map((tag) =>
 			tag.toLowerCase(),
@@ -407,7 +649,7 @@ export class LlmSmartShuffleService {
 		return stableShuffle(tracks)
 			.map((track) => {
 				const row = tagsByTrackId.get(track.id)
-				const tags = row?.tags ?? getLocalTitleTags(track)
+				const tags = getTrackTags(track, tagsByTrackId)
 				const trackTags = allTags(tags)
 				let score = 1
 

--- a/apps/mobile/src/lib/services/llmSmartShuffleService.ts
+++ b/apps/mobile/src/lib/services/llmSmartShuffleService.ts
@@ -1,4 +1,12 @@
 import { inArray, sql } from 'drizzle-orm'
+import {
+	err,
+	errAsync,
+	ok,
+	okAsync,
+	ResultAsync,
+	type Result,
+} from 'neverthrow'
 
 import useAppStore from '@/hooks/stores/useAppStore'
 import db from '@/lib/db/db'
@@ -28,6 +36,7 @@ const logger = log.extend('Service.LlmSmartShuffle')
 
 const MAX_LLM_SORT_TRACKS_PER_PAYLOAD = 200
 const MAX_LLM_SORT_PAYLOAD_BYTES = 200 * 1024
+const DEFAULT_LLM_REQUEST_TIMEOUT_MS = 30_000
 
 const EMPTY_TAGS: TrackLlmTags = {
 	language: [],
@@ -98,13 +107,43 @@ function normalizeTags(value: unknown): TrackLlmTags {
 	}
 }
 
-function parseJsonObject<T>(content: string): T {
+function toError(error: unknown): Error {
+	return error instanceof Error ? error : new Error(String(error))
+}
+
+function getLlmRequestTimeoutMs() {
+	const configuredTimeout = Number(
+		process.env.EXPO_PUBLIC_LLM_REQUEST_TIMEOUT_MS,
+	)
+	return Number.isFinite(configuredTimeout) && configuredTimeout > 0
+		? configuredTimeout
+		: DEFAULT_LLM_REQUEST_TIMEOUT_MS
+}
+
+function toLlmRequestError(error: unknown, timeoutMs: number): Error {
+	const requestError = toError(error)
+	if (requestError.name === 'AbortError') {
+		return new Error(`LLM API 请求超时：${timeoutMs}ms`)
+	}
+	return requestError
+}
+
+function parseJsonObject<T>(content: string): Result<T, Error> {
 	try {
-		return JSON.parse(content) as T
+		return ok(JSON.parse(content) as T)
 	} catch {
 		const match = content.match(/\{[\s\S]*\}/)
-		if (!match) throw new Error('LLM 没有返回 JSON 对象')
-		return JSON.parse(match[0]) as T
+		if (!match) return err(new Error('LLM 没有返回 JSON 对象'))
+
+		try {
+			return ok(JSON.parse(match[0]) as T)
+		} catch (fallbackError) {
+			return err(
+				new Error(
+					`LLM 返回的 JSON 对象无效：${toError(fallbackError).message}`,
+				),
+			)
+		}
 	}
 }
 
@@ -251,153 +290,192 @@ export class LlmSmartShuffleService {
 		)
 	}
 
-	private async callJson<T>(system: string, user: string): Promise<T> {
+	private callJson<T>(system: string, user: string): ResultAsync<T, Error> {
 		const settings = useAppStore.getState().settings
 		const url = `${normalizeBaseUrl(settings.llmBaseUrl)}/chat/completions`
 		const headers: Record<string, string> = {
 			'Content-Type': 'application/json',
 		}
-		await llmCredentialService.migrateFromPlainSettings()
-		const apiKey = await llmCredentialService.getApiKey()
-		if (apiKey) {
-			headers.Authorization = `Bearer ${apiKey}`
-		}
+		const timeoutMs = getLlmRequestTimeoutMs()
 
-		const response = await fetch(url, {
-			method: 'POST',
-			headers,
-			body: JSON.stringify({
-				model: settings.llmModel.trim(),
-				temperature: 0.1,
-				response_format: { type: 'json_object' },
-				messages: [
-					{ role: 'system', content: system },
-					{ role: 'user', content: user },
-				],
-			}),
-		})
+		return ResultAsync.fromPromise(
+			(async () => {
+				await llmCredentialService.migrateFromPlainSettings()
+				const apiKey = await llmCredentialService.getApiKey()
+				if (apiKey) {
+					headers.Authorization = `Bearer ${apiKey}`
+				}
 
-		if (!response.ok) {
-			throw new Error(`LLM API 请求失败：${response.status}`)
-		}
-
-		const data = (await response.json()) as OpenAIChatCompletionResponse
-		const content = data.choices?.[0]?.message?.content
-		if (!content) {
-			throw new Error('LLM API 没有返回内容')
-		}
-		return parseJsonObject<T>(content)
+				const controller = new AbortController()
+				const timeout = setTimeout(() => controller.abort(), timeoutMs)
+				try {
+					return await fetch(url, {
+						method: 'POST',
+						headers,
+						signal: controller.signal,
+						body: JSON.stringify({
+							model: settings.llmModel.trim(),
+							temperature: 0.1,
+							response_format: { type: 'json_object' },
+							messages: [
+								{ role: 'system', content: system },
+								{ role: 'user', content: user },
+							],
+						}),
+					})
+				} finally {
+					clearTimeout(timeout)
+				}
+			})(),
+			(error) => toLlmRequestError(error, timeoutMs),
+		)
+			.andThen((response) => {
+				if (!response.ok) {
+					return errAsync(new Error(`LLM API 请求失败：${response.status}`))
+				}
+				return ResultAsync.fromPromise(
+					response.json() as Promise<OpenAIChatCompletionResponse>,
+					toError,
+				)
+			})
+			.andThen((data) => {
+				const content = data.choices?.[0]?.message?.content
+				if (!content) {
+					return errAsync(new Error('LLM API 没有返回内容'))
+				}
+				const parsed = parseJsonObject<T>(content)
+				return parsed.isOk() ? okAsync(parsed.value) : errAsync(parsed.error)
+			})
 	}
 
-	async indexTracks(contexts: TrackIndexContext[]) {
-		if (!this.isConfigured() || contexts.length === 0) return
+	indexTracks(contexts: TrackIndexContext[]): ResultAsync<void, Error> {
+		if (!this.isConfigured() || contexts.length === 0) return okAsync(undefined)
+
+		let result = okAsync<void, Error>(undefined)
 		for (let i = 0; i < contexts.length; i += 25) {
-			await this.indexTrackBatch(contexts.slice(i, i + 25))
+			const batch = contexts.slice(i, i + 25)
+			result = result.andThen(() => this.indexTrackBatch(batch))
 		}
+		return result
 	}
 
-	private async indexTrackBatch(contexts: TrackIndexContext[]) {
+	private indexTrackBatch(
+		contexts: TrackIndexContext[],
+	): ResultAsync<void, Error> {
 		const settings = useAppStore.getState().settings
 
-		const response = await this.callJson<{ tracks?: unknown[] }>(
+		return this.callJson<{ tracks?: unknown[] }>(
 			LLM_TAG_INDEX_SYSTEM_PROMPT,
 			buildTrackTagIndexPrompt(contexts, EMPTY_TAGS),
 		)
+			.map((response) =>
+				(response.tracks ?? [])
+					.map((item) => {
+						if (!item || typeof item !== 'object') return null
+						const row = item as Record<string, unknown>
+						const trackId = Number(row.trackId)
+						if (!Number.isFinite(trackId)) return null
+						const index: TrackTagIndex = {
+							trackId,
+							tags: normalizeTags(row.tags),
+							confidence:
+								typeof row.confidence === 'number'
+									? Math.max(0, Math.min(1, row.confidence))
+									: 0,
+						}
+						if (typeof row.reason === 'string') index.reason = row.reason
+						return index
+					})
+					.filter((item): item is TrackTagIndex => item !== null),
+			)
+			.andThen((indexes) => {
+				if (indexes.length === 0) return okAsync(undefined)
 
-		const indexes = (response.tracks ?? [])
-			.map((item) => {
-				if (!item || typeof item !== 'object') return null
-				const row = item as Record<string, unknown>
-				const trackId = Number(row.trackId)
-				if (!Number.isFinite(trackId)) return null
-				const index: TrackTagIndex = {
-					trackId,
-					tags: normalizeTags(row.tags),
-					confidence:
-						typeof row.confidence === 'number'
-							? Math.max(0, Math.min(1, row.confidence))
-							: 0,
-				}
-				if (typeof row.reason === 'string') index.reason = row.reason
-				return index
-			})
-			.filter((item): item is TrackTagIndex => item !== null)
-
-		if (indexes.length === 0) return
-
-		const contextById = new Map(contexts.map((item) => [item.track.id, item]))
-		await db
-			.insert(schema.trackLlmTags)
-			.values(
-				indexes.map((index) => {
+				const contextById = new Map(
+					contexts.map((item) => [item.track.id, item]),
+				)
+				const values = indexes.flatMap((index) => {
 					const context = contextById.get(index.trackId)
+					if (!context) return []
+
 					return {
-						trackId: index.trackId,
+						trackId: context.track.id,
 						tags: index.tags,
 						confidence: index.confidence,
 						reason: index.reason,
 						model: settings.llmModel.trim(),
-						sourceType: context?.sourceType,
-						sourceId: context?.sourceId,
-						sourceSyncedAt: context?.sourceSyncedAt,
+						sourceType: context.sourceType,
+						sourceId: context.sourceId,
+						sourceSyncedAt: context.sourceSyncedAt,
 						indexedAt: new Date(),
 					}
-				}),
-			)
-			.onConflictDoUpdate({
-				target: schema.trackLlmTags.trackId,
-				set: {
-					tags: sql`excluded.tags`,
-					confidence: sql`excluded.confidence`,
-					reason: sql`excluded.reason`,
-					model: sql`excluded.model`,
-					sourceType: sql`excluded.source_type`,
-					sourceId: sql`excluded.source_id`,
-					sourceSyncedAt: sql`excluded.source_synced_at`,
-					indexedAt: new Date(),
-				},
+				})
+				if (values.length === 0) return okAsync(undefined)
+
+				return ResultAsync.fromPromise(
+					db
+						.insert(schema.trackLlmTags)
+						.values(values)
+						.onConflictDoUpdate({
+							target: schema.trackLlmTags.trackId,
+							set: {
+								tags: sql`excluded.tags`,
+								confidence: sql`excluded.confidence`,
+								reason: sql`excluded.reason`,
+								model: sql`excluded.model`,
+								sourceType: sql`excluded.source_type`,
+								sourceId: sql`excluded.source_id`,
+								sourceSyncedAt: sql`excluded.source_synced_at`,
+								indexedAt: new Date(),
+							},
+						}),
+					toError,
+				).map(() => undefined)
 			})
 	}
 
-	async indexPlaylistTracks(
+	indexPlaylistTracks(
 		playlistId: number,
 		options?: {
 			sourceType?: Playlist['type']
 			sourceId?: string
 			sourceSyncedAt?: Date
 		},
-	) {
-		try {
-			const tracksResult = await playlistService.getPlaylistTracks(playlistId)
-			if (tracksResult.isErr()) {
-				logger.warning('获取歌单歌曲用于 LLM 索引失败', tracksResult.error)
-				return
-			}
-			await this.indexTracks(
-				tracksResult.value.map((track) => ({
-					track,
-					sourceType: options?.sourceType,
-					sourceId: options?.sourceId,
-					sourceSyncedAt: options?.sourceSyncedAt,
-				})),
-			)
-		} catch (error) {
-			logger.warning('LLM 标签索引失败', { error })
-		}
+	): ResultAsync<void, Error> {
+		return ResultAsync.fromPromise(
+			playlistService.getPlaylistTracks(playlistId),
+			toError,
+		)
+			.andThen((tracksResult) => {
+				if (tracksResult.isErr()) {
+					return errAsync(toError(tracksResult.error))
+				}
+				return this.indexTracks(
+					tracksResult.value.map((track) => ({
+						track,
+						sourceType: options?.sourceType,
+						sourceId: options?.sourceId,
+						sourceSyncedAt: options?.sourceSyncedAt,
+					})),
+				)
+			})
+			.mapErr((error) => {
+				logger.warning('LLM 标签索引失败', { error })
+				return error
+			})
 	}
 
-	async parsePreference(prompt: string): Promise<SmartShufflePreference> {
+	parsePreference(prompt: string): ResultAsync<SmartShufflePreference, Error> {
 		const trimmed = prompt.trim()
 		if (!trimmed || !this.isConfigured()) {
-			return parsePreferenceLocally(trimmed)
+			return okAsync(parsePreferenceLocally(trimmed))
 		}
 
-		try {
-			const response = await this.callJson<Partial<SmartShufflePreference>>(
-				LLM_PREFERENCE_SYSTEM_PROMPT,
-				buildPreferencePrompt(trimmed, DEFAULT_PREFERENCE),
-			)
-			return {
+		return this.callJson<Partial<SmartShufflePreference>>(
+			LLM_PREFERENCE_SYSTEM_PROMPT,
+			buildPreferencePrompt(trimmed, DEFAULT_PREFERENCE),
+		)
+			.map((response) => ({
 				preferredTags: asStringArray(response.preferredTags),
 				downrankTags: asStringArray(response.downrankTags),
 				timeBias:
@@ -414,64 +492,69 @@ export class LlmSmartShuffleService {
 						: 'balanced',
 				repeatAvoidance: response.repeatAvoidance ?? true,
 				temporary: response.temporary ?? true,
-			}
-		} catch (error) {
-			logger.warning('LLM 解析偏好失败，使用本地关键词规则', { error })
-			return parsePreferenceLocally(trimmed)
-		}
+			}))
+			.orElse((error) => {
+				logger.warning('LLM 解析偏好失败，使用本地关键词规则', { error })
+				return okAsync(parsePreferenceLocally(trimmed))
+			})
 	}
 
-	async createSmartQueue(
+	createSmartQueue(
 		tracks: Track[],
 		options?: SmartQueueOptions,
-	): Promise<Track[]> {
-		if (tracks.length <= 1) return tracks
+	): ResultAsync<Track[], Error> {
+		if (tracks.length <= 1) return okAsync(tracks)
 
 		const prompt =
 			options?.prompt?.trim() || options?.defaultPreference?.trim() || ''
-		const preference = await this.parsePreference(prompt)
-		const tagRows = await db.query.trackLlmTags.findMany({
-			where: inArray(
-				schema.trackLlmTags.trackId,
-				tracks.map((track) => track.id),
-			),
-		})
-		const tagsByTrackId = new Map<number, TrackLlmTagRow>(
-			tagRows.map((row) => [row.trackId, row]),
+		return this.parsePreference(prompt).andThen((preference) =>
+			ResultAsync.fromPromise(
+				db.query.trackLlmTags.findMany({
+					where: inArray(
+						schema.trackLlmTags.trackId,
+						tracks.map((track) => track.id),
+					),
+				}),
+				toError,
+			).andThen((tagRows) => {
+				const tagsByTrackId = new Map<number, TrackLlmTagRow>(
+					tagRows.map((row) => [row.trackId, row]),
+				)
+				return this.createLlmSortedQueue(
+					tracks,
+					prompt,
+					preference,
+					tagsByTrackId,
+				).map(
+					(llmSortedQueue) =>
+						llmSortedQueue ??
+						this.createLocalScoredQueue(tracks, preference, tagsByTrackId),
+				)
+			}),
 		)
-
-		const llmSortedQueue = await this.createLlmSortedQueue(
-			tracks,
-			prompt,
-			preference,
-			tagsByTrackId,
-		)
-		if (llmSortedQueue) return llmSortedQueue
-
-		return this.createLocalScoredQueue(tracks, preference, tagsByTrackId)
 	}
 
-	private async createLlmSortedQueue(
+	private createLlmSortedQueue(
 		tracks: Track[],
 		prompt: string,
 		preference: SmartShufflePreference,
 		tagsByTrackId: Map<number, TrackLlmTagRow>,
-	) {
-		if (!this.isConfigured()) return null
+	): ResultAsync<Track[] | null, Error> {
+		if (!this.isConfigured()) return okAsync(null)
 
-		try {
-			const fallbackOrder = this.createLocalScoredQueue(
-				tracks,
-				preference,
-				tagsByTrackId,
-			)
-			const items = tracks.map((track) =>
-				this.createSortPromptItem(track, tagsByTrackId),
-			)
-			const chunks = this.createSortPayloadChunks(prompt, preference, items)
-			const chunkOrders = await Promise.all(
+		const fallbackOrder = this.createLocalScoredQueue(
+			tracks,
+			preference,
+			tagsByTrackId,
+		)
+		const items = tracks.map((track) =>
+			this.createSortPromptItem(track, tagsByTrackId),
+		)
+		const chunks = this.createSortPayloadChunks(prompt, preference, items)
+		return ResultAsync.fromPromise(
+			Promise.all(
 				chunks.map(async (chunk, index) => {
-					const response = await this.callJson<{
+					const chunkOrderResult = await this.callJson<{
 						orderedTrackIds?: unknown
 						trackIds?: unknown
 						tracks?: unknown
@@ -484,20 +567,42 @@ export class LlmSmartShuffleService {
 							chunkIndex: index + 1,
 							chunkCount: chunks.length,
 						}),
-					)
-					const chunkTrackIds = new Set(chunk.map((item) => item.track.id))
-					const chunkFallback = fallbackOrder.filter((track) =>
-						chunkTrackIds.has(track.id),
-					)
-					return this.mergeLlmOrderWithFallback(
-						chunk.map((item) => item.track),
-						extractOrderedTrackIds(response),
-						chunkFallback,
-					)
+					).map((response) => {
+						const chunkTrackIds = new Set(chunk.map((item) => item.track.id))
+						const chunkFallback = fallbackOrder.filter((track) =>
+							chunkTrackIds.has(track.id),
+						)
+						return this.mergeLlmOrderWithFallback(
+							chunk.map((item) => item.track),
+							extractOrderedTrackIds(response),
+							chunkFallback,
+						)
+					})
+					if (chunkOrderResult.isErr()) {
+						logger.warning('LLM 排序分片失败', {
+							error: chunkOrderResult.error,
+							chunkIndex: index + 1,
+						})
+						return err(chunkOrderResult.error)
+					}
+					return ok(chunkOrderResult.value)
 				}),
-			)
-
-			if (chunkOrders.some((chunk) => chunk === null)) return null
+			),
+			toError,
+		).andThen((chunkOrderResults) => {
+			const failedChunk = chunkOrderResults.find((result) => result.isErr())
+			if (failedChunk?.isErr()) {
+				logger.warning('LLM 直接排序失败，使用本地标签打分', {
+					error: failedChunk.error,
+				})
+				return okAsync(null)
+			}
+			const chunkOrders: (Track[] | null)[] = []
+			for (const result of chunkOrderResults) {
+				if (result.isErr()) return okAsync(null)
+				chunkOrders.push(result.value)
+			}
+			if (chunkOrders.some((chunk) => chunk === null)) return okAsync(null)
 
 			const orderedTrackIds =
 				chunkOrders.length === 1
@@ -507,15 +612,10 @@ export class LlmSmartShuffleService {
 							fallbackOrder,
 						).map((track) => track.id)
 
-			return this.mergeLlmOrderWithFallback(
-				tracks,
-				orderedTrackIds,
-				fallbackOrder,
+			return okAsync(
+				this.mergeLlmOrderWithFallback(tracks, orderedTrackIds, fallbackOrder),
 			)
-		} catch (error) {
-			logger.warning('LLM 直接排序失败，使用本地标签打分', { error })
-			return null
-		}
+		})
 	}
 
 	private createSortPromptItem(

--- a/apps/mobile/src/lib/services/llmSmartShuffleService.ts
+++ b/apps/mobile/src/lib/services/llmSmartShuffleService.ts
@@ -242,34 +242,37 @@ export class LlmSmartShuffleService {
 					'优先识别语种、Vocaloid/中V/日V、风格、情绪、场景。',
 					'无法判断的字段返回空数组。',
 				],
-				tracks: contexts.map(({ track, sourceType, sourceId, sourceSyncedAt }) => ({
-					trackId: track.id,
-					title: track.title,
-					artist: track.artist?.name,
-					source: track.source,
-					sourceType,
-					sourceId,
-					sourceSyncedAt: sourceSyncedAt?.toISOString(),
-					firstSeenAt: track.createdAt.toISOString(),
-				})),
+				tracks: contexts.map(
+					({ track, sourceType, sourceId, sourceSyncedAt }) => ({
+						trackId: track.id,
+						title: track.title,
+						artist: track.artist?.name,
+						source: track.source,
+						sourceType,
+						sourceId,
+						sourceSyncedAt: sourceSyncedAt?.toISOString(),
+						firstSeenAt: track.createdAt.toISOString(),
+					}),
+				),
 			}),
 		)
 
-		const indexes: TrackTagIndex[] = (response.tracks ?? [])
+		const indexes = (response.tracks ?? [])
 			.map((item) => {
 				if (!item || typeof item !== 'object') return null
 				const row = item as Record<string, unknown>
 				const trackId = Number(row.trackId)
 				if (!Number.isFinite(trackId)) return null
-				return {
+				const index: TrackTagIndex = {
 					trackId,
 					tags: normalizeTags(row.tags),
 					confidence:
 						typeof row.confidence === 'number'
 							? Math.max(0, Math.min(1, row.confidence))
 							: 0,
-					reason: typeof row.reason === 'string' ? row.reason : undefined,
 				}
+				if (typeof row.reason === 'string') index.reason = row.reason
+				return index
 			})
 			.filter((item): item is TrackTagIndex => item !== null)
 

--- a/apps/mobile/src/lib/services/llmSmartShuffleService.ts
+++ b/apps/mobile/src/lib/services/llmSmartShuffleService.ts
@@ -3,6 +3,7 @@ import { inArray, sql } from 'drizzle-orm'
 import useAppStore from '@/hooks/stores/useAppStore'
 import db from '@/lib/db/db'
 import * as schema from '@/lib/db/schema'
+import { llmCredentialService } from '@/lib/services/llmCredentialService'
 import { playlistService } from '@/lib/services/playlistService'
 import type { Playlist, Track } from '@/types/core/media'
 import type {
@@ -183,8 +184,10 @@ export class LlmSmartShuffleService {
 		const headers: Record<string, string> = {
 			'Content-Type': 'application/json',
 		}
-		if (settings.llmApiKey.trim()) {
-			headers.Authorization = `Bearer ${settings.llmApiKey.trim()}`
+		await llmCredentialService.migrateFromPlainSettings()
+		const apiKey = await llmCredentialService.getApiKey()
+		if (apiKey) {
+			headers.Authorization = `Bearer ${apiKey}`
 		}
 
 		const response = await fetch(url, {

--- a/apps/mobile/src/types/core/appStore.ts
+++ b/apps/mobile/src/types/core/appStore.ts
@@ -12,6 +12,12 @@ interface Settings {
 	enableDataCollection: boolean
 	enableDanmaku: boolean
 	danmakuFilterLevel: number
+	enableLlmTagging: boolean
+	allowLlmMetadataUpload: boolean
+	llmBaseUrl: string
+	llmApiKey: string
+	llmModel: string
+	llmDefaultPreference: string
 }
 
 interface BilibiliUserSummary {

--- a/apps/mobile/src/types/core/appStore.ts
+++ b/apps/mobile/src/types/core/appStore.ts
@@ -15,7 +15,7 @@ interface Settings {
 	enableLlmTagging: boolean
 	allowLlmMetadataUpload: boolean
 	llmBaseUrl: string
-	llmApiKey: string
+	llmApiKey?: string
 	llmModel: string
 	llmDefaultPreference: string
 }

--- a/apps/mobile/src/types/navigation.ts
+++ b/apps/mobile/src/types/navigation.ts
@@ -43,6 +43,8 @@ export interface ModalPropsMap {
 	}
 	DanmakuSettings: undefined
 	CoverDownloadProgress: undefined
+	LlmSmartShuffleSettings: undefined
+	SmartShuffle: { playlistId: number }
 	EnableSharing: {
 		playlistId: number
 		shareId?: string | null

--- a/apps/mobile/src/types/services/llmSmartShuffle.ts
+++ b/apps/mobile/src/types/services/llmSmartShuffle.ts
@@ -1,0 +1,38 @@
+import type { Playlist, Track } from '@/types/core/media'
+
+export interface TrackLlmTags {
+	language: string[]
+	vocalType: string[]
+	genre: string[]
+	mood: string[]
+	scene: string[]
+	timePreference: string[]
+}
+
+export interface TrackTagIndex {
+	trackId: number
+	tags: TrackLlmTags
+	confidence: number
+	reason?: string
+}
+
+export interface SmartShufflePreference {
+	preferredTags: string[]
+	downrankTags: string[]
+	timeBias: 'recent' | 'old' | 'balanced'
+	explorationLevel: 'conservative' | 'balanced' | 'exploratory'
+	repeatAvoidance: boolean
+	temporary: boolean
+}
+
+export interface TrackIndexContext {
+	track: Track
+	sourceType?: Playlist['type']
+	sourceId?: string
+	sourceSyncedAt?: Date
+}
+
+export interface SmartQueueOptions {
+	prompt?: string
+	defaultPreference?: string
+}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,22 +2,17 @@ pre-commit:
   parallel: true
   commands:
     gitleaks:
-      run: |
-        if command -v gitleaks > /dev/null 2>&1; then
-          gitleaks protect --staged --verbose $([ -f .gitleaks-baseline.json ] && echo "--baseline-path .gitleaks-baseline.json")
-        else
-          echo "⚠️ gitleaks is not installed, skipping secret scan. Install with: brew install gitleaks"
-        fi
-    lint-and-format-codes:
+      run: node scripts/lefthook-gitleaks.cjs
+    format-codes:
       glob: '*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,yml,yaml,toml}'
-      run: |
-        if [ -z "{staged_files}" ]; then
-          echo "No staged files to lint or format."
-          exit 0
-        fi
-
-        pnpm oxfmt --write "{staged_files}" && pnpm oxlint --type-aware "{staged_files}" && pnpm eslint "{staged_files}"
+      run: pnpm oxfmt --write {staged_files}
       stage_fixed: true
+    oxlint-codes:
+      glob: '*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,yml,yaml,toml}'
+      run: pnpm oxlint --type-aware {staged_files}
+    eslint-codes:
+      glob: '*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,yml,yaml,toml}'
+      run: pnpm eslint {staged_files}
     format-plain-text:
       glob: '*.{md,mdx}'
       run: pnpm oxfmt --write "{staged_files}"

--- a/packages/image-theme-colors/android/build.gradle
+++ b/packages/image-theme-colors/android/build.gradle
@@ -28,22 +28,22 @@ if (useManagedAndroidSdkVersions) {
         }
     }
     project.android {
-        compileSdkVersion safeExtGet("compileSdkVersion", 36)
+        compileSdkVersion = safeExtGet("compileSdkVersion", 36)
         defaultConfig {
-            minSdkVersion safeExtGet("minSdkVersion", 24)
-            targetSdkVersion safeExtGet("targetSdkVersion", 36)
+            minSdkVersion = safeExtGet("minSdkVersion", 24)
+            targetSdkVersion = safeExtGet("targetSdkVersion", 36)
         }
     }
 }
 
 android {
-    namespace "expo.modules.imagethemecolors"
+    namespace = "expo.modules.imagethemecolors"
     defaultConfig {
-        versionCode 1
-        versionName packageJson.version
+        versionCode = 1
+        versionName = packageJson.version
     }
-    lintOptions {
-        abortOnError false
+    lint {
+        abortOnError = false
     }
 }
 

--- a/packages/image-theme-colors/android/src/main/java/expo/modules/imagethemecolors/ExpoImageThemeColorsModule.kt
+++ b/packages/image-theme-colors/android/src/main/java/expo/modules/imagethemecolors/ExpoImageThemeColorsModule.kt
@@ -1,12 +1,9 @@
-@file:OptIn(EitherType::class)
-
 package expo.modules.imagethemecolors
 
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import androidx.palette.graphics.Palette
-import expo.modules.kotlin.apifeatures.EitherType
 import expo.modules.kotlin.exception.CodedException
 import expo.modules.kotlin.exception.Exceptions
 import expo.modules.kotlin.exception.toCodedException

--- a/packages/orpheus/android/build.gradle
+++ b/packages/orpheus/android/build.gradle
@@ -31,25 +31,25 @@ if (useManagedAndroidSdkVersions) {
         }
     }
     project.android {
-        compileSdkVersion safeExtGet("compileSdkVersion", 36)
+        compileSdkVersion = safeExtGet("compileSdkVersion", 36)
         defaultConfig {
-            minSdkVersion safeExtGet("minSdkVersion", 24)
-            targetSdkVersion safeExtGet("targetSdkVersion", 36)
+            minSdkVersion = safeExtGet("minSdkVersion", 24)
+            targetSdkVersion = safeExtGet("targetSdkVersion", 36)
         }
     }
 }
 
 android {
-    namespace "expo.modules.orpheus"
+    namespace = "expo.modules.orpheus"
     defaultConfig {
-        versionCode 1
-        versionName packageJson.version
+        versionCode = 1
+        versionName = packageJson.version
     }
     buildFeatures {
         aidl = true
     }
-    lintOptions {
-        abortOnError false
+    lint {
+        abortOnError = false
     }
     kotlinOptions {
         freeCompilerArgs += [

--- a/patches/expo-modules-core@55.0.13.patch
+++ b/patches/expo-modules-core@55.0.13.patch
@@ -1,0 +1,18 @@
+diff --git a/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt b/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt
+index 9bfae8d7961d6f63c1b17c1b0d4f01557e15a424..4e14872b82c053c0bddb6d95bab9a7e127a29803 100644
+--- a/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt
++++ b/expo-module-gradle-plugin/src/main/kotlin/expo/modules/plugin/android/AndroidLibraryExtension.kt
+@@ -6,7 +6,12 @@ internal fun LibraryExtension.applySDKVersions(compileSdk: Int, minSdk: Int, tar
+   this.compileSdk = compileSdk
+   defaultConfig {
+     this@defaultConfig.minSdk = minSdk
+-    this@defaultConfig.targetSdk = targetSdk
++  }
++  testOptions {
++    this@testOptions.targetSdk = targetSdk
++  }
++  lint {
++    this@lint.targetSdk = targetSdk
+   }
+ }
+ 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  expo-modules-core@55.0.13:
+    hash: 90bbfc6b7629bb733ac4a8b5d5cc858dc25242348ea530be70f11cc57f99929e
+    path: patches/expo-modules-core@55.0.13.patch
   react-native-mmkv:
     hash: 6e8deefa8d5d01876543db78916bed5aaa62cd8d7b33c0557e486f0f9d8d4b52
     path: patches/react-native-mmkv.patch
@@ -274,7 +277,7 @@ importers:
         version: 55.0.9(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))
       expo-router:
         specifier: 55.0.3
-        version: 55.0.3(697db82ccada3675a0ce8872afb9b9ab)
+        version: 55.0.3(2187545d5958cd362e6c0e2e98a9b4ea)
       expo-secure-store:
         specifier: ~55.0.13
         version: 55.0.13(expo@55.0.4)
@@ -452,7 +455,7 @@ importers:
         version: 5.91.4(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@testing-library/react-native':
         specifier: ^13.3.3
-        version: 13.3.3(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 13.3.3(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/color':
         specifier: ^4.2.0
         version: 4.2.0
@@ -518,7 +521,7 @@ importers:
         version: 16.5.0
       jest-expo:
         specifier: ^55.0.5
-        version: 55.0.5(@babel/core@7.28.6)(expo@55.0.4)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+        version: 55.0.5(@babel/core@7.28.6)(expo@55.0.4)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
       lefthook:
         specifier: ^1.13.6
         version: 1.13.6
@@ -542,7 +545,7 @@ importers:
         version: 1.0.0(@discoveryjs/discovery@1.0.0-beta.93)(metro@0.83.3)
       ts-jest:
         specifier: ^29.4.1
-        version: 29.4.1(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(esbuild@0.25.12)(jest-util@30.2.0)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.1(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(esbuild@0.27.3)(jest-util@30.2.0)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@25.2.3)(typescript@5.9.3)
@@ -12061,7 +12064,7 @@ snapshots:
       ws: 8.19.0
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.3(697db82ccada3675a0ce8872afb9b9ab)
+      expo-router: 55.0.3(878ca7561275bf15c90181fbe15e6193)
       react-native: 0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12386,7 +12389,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@0.2.8)(expo@55.0.4)(react-dom@19.1.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      expo-router: 55.0.3(697db82ccada3675a0ce8872afb9b9ab)
+      expo-router: 55.0.3(878ca7561275bf15c90181fbe15e6193)
       react-dom: 19.1.0(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -12963,6 +12966,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   '@jest/core@30.2.0(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))':
     dependencies:
@@ -14415,6 +14419,7 @@ snapshots:
       redent: 3.0.0
     optionalDependencies:
       jest: 30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))
+    optional: true
 
   '@testing-library/react-native@13.3.3(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -16561,21 +16566,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -16647,7 +16653,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -17104,13 +17110,62 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-modules-core@55.0.13(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0):
+  expo-modules-core@55.0.13(patch_hash=90bbfc6b7629bb733ac4a8b5d5cc858dc25242348ea530be70f11cc57f99929e)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0):
     dependencies:
       invariant: 2.2.4
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0)
 
-  expo-router@55.0.3(697db82ccada3675a0ce8872afb9b9ab):
+  expo-router@55.0.3(2187545d5958cd362e6c0e2e98a9b4ea):
+    dependencies:
+      '@expo/log-box': 55.0.7(@expo/dom-webview@0.2.8)(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      '@expo/metro-runtime': 55.0.6(@expo/dom-webview@0.2.8)(expo@55.0.4)(react-dom@19.1.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      '@expo/schema-utils': 55.0.2
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.9)(react@19.2.0)
+      '@radix-ui/react-tabs': 1.1.13(@types/react@19.2.9)(react-dom@19.1.0(react@19.2.0))(react@19.2.0)
+      '@react-navigation/bottom-tabs': 7.10.1(@react-native-masked-view/masked-view@0.3.2(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      '@react-navigation/native': 7.1.28(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      '@react-navigation/native-stack': 7.10.1(@react-native-masked-view/masked-view@0.3.2(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      client-only: 0.0.1
+      debug: 4.4.3
+      escape-string-regexp: 4.0.0
+      expo: 55.0.4(@babel/core@7.28.6)(@expo/dom-webview@0.2.8)(@expo/metro-runtime@55.0.6)(expo-router@55.0.3)(react-dom@19.1.0(react@19.2.0))(react-native-webview@13.15.0(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-constants: 55.0.7(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(typescript@5.9.3)
+      expo-glass-effect: 55.0.7(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      expo-image: 55.0.5(expo@55.0.4)(react-native-web@0.21.1(react-dom@19.1.0(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      expo-linking: 55.0.7(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+      expo-server: 55.0.6
+      expo-symbols: 55.0.4(expo-font@55.0.4)(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      fast-deep-equal: 3.1.3
+      invariant: 2.2.4
+      nanoid: 3.3.11
+      query-string: 7.1.3
+      react: 19.2.0
+      react-fast-compare: 3.2.2
+      react-native: 0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0)
+      react-native-is-edge-to-edge: 1.2.1(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      react-native-safe-area-context: 5.6.2(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      react-native-screens: 4.23.0(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      semver: 7.6.3
+      server-only: 0.0.1
+      sf-symbols-typescript: 2.2.0
+      shallowequal: 1.1.0
+      use-latest-callback: 0.2.6(react@19.2.0)
+      vaul: 1.1.2(@types/react@19.2.9)(react-dom@19.1.0(react@19.2.0))(react@19.2.0)
+    optionalDependencies:
+      '@testing-library/react-native': 13.3.3(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)
+      react-dom: 19.1.0(react@19.2.0)
+      react-native-gesture-handler: 2.30.0(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      react-native-reanimated: 4.2.2(react-native-worklets@0.7.4(@babel/core@7.28.6)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      react-native-web: 0.21.1(react-dom@19.1.0(react@19.2.0))(react@19.2.0)
+    transitivePeerDependencies:
+      - '@react-native-masked-view/masked-view'
+      - '@types/react'
+      - '@types/react-dom'
+      - expo-font
+      - supports-color
+
+  expo-router@55.0.3(878ca7561275bf15c90181fbe15e6193):
     dependencies:
       '@expo/log-box': 55.0.7(@expo/dom-webview@0.2.8)(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@0.2.8)(expo@55.0.4)(react-dom@19.1.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
@@ -17158,6 +17213,7 @@ snapshots:
       - '@types/react-dom'
       - expo-font
       - supports-color
+    optional: true
 
   expo-secure-store@55.0.13(expo@55.0.4):
     dependencies:
@@ -17266,7 +17322,7 @@ snapshots:
       expo-font: 55.0.4(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
       expo-keep-awake: 55.0.4(expo@55.0.4)(react@19.2.0)
       expo-modules-autolinking: 55.0.8(typescript@5.9.3)
-      expo-modules-core: 55.0.13(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+      expo-modules-core: 55.0.13(patch_hash=90bbfc6b7629bb733ac4a8b5d5cc858dc25242348ea530be70f11cc57f99929e)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
       pretty-format: 29.7.0
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0)
@@ -18226,6 +18282,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   jest-cli@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)):
     dependencies:
@@ -18279,6 +18336,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
+    optional: true
 
   jest-config@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)):
     dependencies:
@@ -18401,7 +18459,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-expo@55.0.5(@babel/core@7.28.6)(expo@55.0.4)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0):
+  jest-expo@55.0.5(@babel/core@7.28.6)(expo@55.0.4)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0):
     dependencies:
       '@expo/config': 55.0.3
       '@expo/json-file': 10.0.11
@@ -18412,7 +18470,7 @@ snapshots:
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))
+      jest-watch-typeahead: 2.2.1(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))
       json5: 2.2.3
       lodash: 4.17.21
       react-native: 0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0)
@@ -18689,17 +18747,6 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
-  jest-watch-typeahead@2.2.1(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))):
-    dependencies:
-      ansi-escapes: 6.2.1
-      chalk: 4.1.2
-      jest: 30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))
-      jest-regex-util: 29.6.3
-      jest-watcher: 29.7.0
-      slash: 5.1.0
-      string-length: 5.0.1
-      strip-ansi: 7.1.2
-
   jest-watch-typeahead@2.2.1(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))):
     dependencies:
       ansi-escapes: 6.2.1
@@ -18760,6 +18807,7 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
+    optional: true
 
   jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)):
     dependencies:
@@ -21331,27 +21379,6 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.28.6)
       esbuild: 0.27.3
-
-  ts-jest@29.4.1(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(esbuild@0.25.12)(jest-util@30.2.0)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
-      jest: 30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.3
-      type-fest: 4.41.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.6
-      '@jest/transform': 30.2.0
-      '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.28.6)
-      esbuild: 0.25.12
-      jest-util: 30.2.0
 
   ts-jest@29.4.1(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(esbuild@0.27.3)(jest-util@30.2.0)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,7 +274,7 @@ importers:
         version: 55.0.9(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))
       expo-router:
         specifier: 55.0.3
-        version: 55.0.3(2187545d5958cd362e6c0e2e98a9b4ea)
+        version: 55.0.3(697db82ccada3675a0ce8872afb9b9ab)
       expo-sharing:
         specifier: ~55.0.11
         version: 55.0.11(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
@@ -449,7 +449,7 @@ importers:
         version: 5.91.4(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       '@testing-library/react-native':
         specifier: ^13.3.3
-        version: 13.3.3(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)
+        version: 13.3.3(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)
       '@types/color':
         specifier: ^4.2.0
         version: 4.2.0
@@ -489,6 +489,9 @@ importers:
       babel-plugin-transform-remove-console:
         specifier: ^6.9.4
         version: 6.9.4
+      cross-env:
+        specifier: ^10.1.0
+        version: 10.1.0
       drizzle-kit:
         specifier: ^0.31.9
         version: 0.31.9
@@ -512,7 +515,7 @@ importers:
         version: 16.5.0
       jest-expo:
         specifier: ^55.0.5
-        version: 55.0.5(@babel/core@7.28.6)(expo@55.0.4)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
+        version: 55.0.5(@babel/core@7.28.6)(expo@55.0.4)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
       lefthook:
         specifier: ^1.13.6
         version: 1.13.6
@@ -536,7 +539,7 @@ importers:
         version: 1.0.0(@discoveryjs/discovery@1.0.0-beta.93)(metro@0.83.3)
       ts-jest:
         specifier: ^29.4.1
-        version: 29.4.1(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(esbuild@0.27.3)(jest-util@30.2.0)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.1(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(esbuild@0.25.12)(jest-util@30.2.0)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@25.2.3)(typescript@5.9.3)
@@ -1575,6 +1578,9 @@ packages:
 
   '@emotion/memoize@0.7.4':
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
+
+  '@epic-web/invariant@1.0.0':
+    resolution: {integrity: sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==}
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
@@ -5491,6 +5497,11 @@ packages:
     resolution: {integrity: sha512-YKGmAy84hKH+hHIIER07VCAHf9u0Ldelx1uU6EBxsRPDXIA1m5fsKmJfyC3xBhw6cVC/1i83VdbL4PvepTrt8A==}
     hasBin: true
 
+  cross-env@10.1.0:
+    resolution: {integrity: sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   cross-fetch@3.2.0:
     resolution: {integrity: sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==}
 
@@ -9286,7 +9297,6 @@ packages:
 
   shaka-player@4.16.1:
     resolution: {integrity: sha512-ieaC0pcn7EPMSXzTi5aXho7gFg2OlduKRgzKPSEMauJMe/pkt6mTWLmVqSsCH7jTRPpiuzF7pFB+/ZHCTWqgHA==}
-    engines: {node: '>=18'}
 
   shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
@@ -11552,6 +11562,8 @@ snapshots:
   '@emotion/memoize@0.7.4':
     optional: true
 
+  '@epic-web/invariant@1.0.0': {}
+
   '@esbuild-kit/core-utils@3.3.2':
     dependencies:
       esbuild: 0.18.20
@@ -12041,7 +12053,7 @@ snapshots:
       ws: 8.19.0
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 55.0.3(878ca7561275bf15c90181fbe15e6193)
+      expo-router: 55.0.3(697db82ccada3675a0ce8872afb9b9ab)
       react-native: 0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -12366,7 +12378,7 @@ snapshots:
       react: 19.2.0
     optionalDependencies:
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@0.2.8)(expo@55.0.4)(react-dom@19.1.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      expo-router: 55.0.3(878ca7561275bf15c90181fbe15e6193)
+      expo-router: 55.0.3(697db82ccada3675a0ce8872afb9b9ab)
       react-dom: 19.1.0(react@19.2.0)
     transitivePeerDependencies:
       - supports-color
@@ -12943,7 +12955,6 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
-    optional: true
 
   '@jest/core@30.2.0(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))':
     dependencies:
@@ -14396,7 +14407,6 @@ snapshots:
       redent: 3.0.0
     optionalDependencies:
       jest: 30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))
-    optional: true
 
   '@testing-library/react-native@13.3.3(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -15941,6 +15951,11 @@ snapshots:
 
   cronstrue@2.59.0: {}
 
+  cross-env@10.1.0:
+    dependencies:
+      '@epic-web/invariant': 1.0.0
+      cross-spawn: 7.0.6
+
   cross-fetch@3.2.0:
     dependencies:
       node-fetch: 2.7.0
@@ -16538,22 +16553,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.2(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-module-utils@2.12.1(@typescript-eslint/parser@8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.54.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
+      eslint: 9.39.2(jiti@2.6.1)
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1)):
+    dependencies:
+      debug: 3.2.7
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -16625,7 +16639,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.53.1(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.55.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -17088,56 +17102,7 @@ snapshots:
       react: 19.2.0
       react-native: 0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0)
 
-  expo-router@55.0.3(2187545d5958cd362e6c0e2e98a9b4ea):
-    dependencies:
-      '@expo/log-box': 55.0.7(@expo/dom-webview@0.2.8)(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      '@expo/metro-runtime': 55.0.6(@expo/dom-webview@0.2.8)(expo@55.0.4)(react-dom@19.1.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      '@expo/schema-utils': 55.0.2
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.9)(react@19.2.0)
-      '@radix-ui/react-tabs': 1.1.13(@types/react@19.2.9)(react-dom@19.1.0(react@19.2.0))(react@19.2.0)
-      '@react-navigation/bottom-tabs': 7.10.1(@react-native-masked-view/masked-view@0.3.2(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      '@react-navigation/native': 7.1.28(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      '@react-navigation/native-stack': 7.10.1(@react-native-masked-view/masked-view@0.3.2(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(@react-navigation/native@7.1.28(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native-safe-area-context@5.6.2(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native-screens@4.23.0(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      client-only: 0.0.1
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      expo: 55.0.4(@babel/core@7.28.6)(@expo/dom-webview@0.2.8)(@expo/metro-runtime@55.0.6)(expo-router@55.0.3)(react-dom@19.1.0(react@19.2.0))(react-native-webview@13.15.0(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      expo-constants: 55.0.7(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(typescript@5.9.3)
-      expo-glass-effect: 55.0.7(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      expo-image: 55.0.5(expo@55.0.4)(react-native-web@0.21.1(react-dom@19.1.0(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      expo-linking: 55.0.7(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
-      expo-server: 55.0.6
-      expo-symbols: 55.0.4(expo-font@55.0.4)(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      fast-deep-equal: 3.1.3
-      invariant: 2.2.4
-      nanoid: 3.3.11
-      query-string: 7.1.3
-      react: 19.2.0
-      react-fast-compare: 3.2.2
-      react-native: 0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0)
-      react-native-is-edge-to-edge: 1.2.1(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      react-native-safe-area-context: 5.6.2(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      react-native-screens: 4.23.0(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      semver: 7.6.3
-      server-only: 0.0.1
-      sf-symbols-typescript: 2.2.0
-      shallowequal: 1.1.0
-      use-latest-callback: 0.2.6(react@19.2.0)
-      vaul: 1.1.2(@types/react@19.2.9)(react-dom@19.1.0(react@19.2.0))(react@19.2.0)
-    optionalDependencies:
-      '@testing-library/react-native': 13.3.3(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react-test-renderer@19.2.0(react@19.2.0))(react@19.2.0)
-      react-dom: 19.1.0(react@19.2.0)
-      react-native-gesture-handler: 2.30.0(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      react-native-reanimated: 4.2.2(react-native-worklets@0.7.4(@babel/core@7.28.6)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
-      react-native-web: 0.21.1(react-dom@19.1.0(react@19.2.0))(react@19.2.0)
-    transitivePeerDependencies:
-      - '@react-native-masked-view/masked-view'
-      - '@types/react'
-      - '@types/react-dom'
-      - expo-font
-      - supports-color
-
-  expo-router@55.0.3(878ca7561275bf15c90181fbe15e6193):
+  expo-router@55.0.3(697db82ccada3675a0ce8872afb9b9ab):
     dependencies:
       '@expo/log-box': 55.0.7(@expo/dom-webview@0.2.8)(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
       '@expo/metro-runtime': 55.0.6(@expo/dom-webview@0.2.8)(expo@55.0.4)(react-dom@19.1.0(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
@@ -17185,7 +17150,6 @@ snapshots:
       - '@types/react-dom'
       - expo-font
       - supports-color
-    optional: true
 
   expo-server@55.0.6: {}
 
@@ -18250,7 +18214,6 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
-    optional: true
 
   jest-cli@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)):
     dependencies:
@@ -18304,7 +18267,6 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
-    optional: true
 
   jest-config@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)):
     dependencies:
@@ -18427,7 +18389,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-expo@55.0.5(@babel/core@7.28.6)(expo@55.0.4)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0):
+  jest-expo@55.0.5(@babel/core@7.28.6)(expo@55.0.4)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0):
     dependencies:
       '@expo/config': 55.0.3
       '@expo/json-file': 10.0.11
@@ -18438,7 +18400,7 @@ snapshots:
       jest-environment-jsdom: 29.7.0
       jest-snapshot: 29.7.0
       jest-watch-select-projects: 2.0.0
-      jest-watch-typeahead: 2.2.1(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))
+      jest-watch-typeahead: 2.2.1(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))
       json5: 2.2.3
       lodash: 4.17.21
       react-native: 0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0)
@@ -18715,6 +18677,17 @@ snapshots:
       chalk: 3.0.0
       prompts: 2.4.2
 
+  jest-watch-typeahead@2.2.1(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))):
+    dependencies:
+      ansi-escapes: 6.2.1
+      chalk: 4.1.2
+      jest: 30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))
+      jest-regex-util: 29.6.3
+      jest-watcher: 29.7.0
+      slash: 5.1.0
+      string-length: 5.0.1
+      strip-ansi: 7.1.2
+
   jest-watch-typeahead@2.2.1(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))):
     dependencies:
       ansi-escapes: 6.2.1
@@ -18775,7 +18748,6 @@ snapshots:
       - esbuild-register
       - supports-color
       - ts-node
-    optional: true
 
   jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)):
     dependencies:
@@ -21347,6 +21319,27 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.28.6)
       esbuild: 0.27.3
+
+  ts-jest@29.4.1(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(esbuild@0.25.12)(jest-util@30.2.0)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.3
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.28.6
+      '@jest/transform': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.28.6)
+      esbuild: 0.25.12
+      jest-util: 30.2.0
 
   ts-jest@29.4.1(@babel/core@7.28.6)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.6))(esbuild@0.27.3)(jest-util@30.2.0)(jest@30.2.0(@types/node@25.2.3)(esbuild-register@3.6.0(esbuild@0.27.3))(ts-node@10.9.2(@types/node@25.2.3)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -275,6 +275,9 @@ importers:
       expo-router:
         specifier: 55.0.3
         version: 55.0.3(697db82ccada3675a0ce8872afb9b9ab)
+      expo-secure-store:
+        specifier: ~55.0.13
+        version: 55.0.13(expo@55.0.4)
       expo-sharing:
         specifier: ~55.0.11
         version: 55.0.11(expo@55.0.4)(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)
@@ -6427,6 +6430,11 @@ packages:
         optional: true
       react-server-dom-webpack:
         optional: true
+
+  expo-secure-store@55.0.13:
+    resolution: {integrity: sha512-I6r0JNO1Fd4o0Gu7Ixiic7s89lqgdUHq17uBH9y1f/AntoyKn71TdtYJH82RgfsBbu5qNVzrwImmvlANyOlITQ==}
+    peerDependencies:
+      expo: '*'
 
   expo-server@55.0.6:
     resolution: {integrity: sha512-xI72FTm469FfuuBL2R5aNtthgH+GR7ygOpsx/KcPS0K8AZaZd7VjtEExbzn9/qyyYkWW3T+3dAmCDKOMX8gdmQ==}
@@ -17150,6 +17158,10 @@ snapshots:
       - '@types/react-dom'
       - expo-font
       - supports-color
+
+  expo-secure-store@55.0.13(expo@55.0.4):
+    dependencies:
+      expo: 55.0.4(@babel/core@7.28.6)(@expo/dom-webview@0.2.8)(@expo/metro-runtime@55.0.6)(expo-router@55.0.3)(react-dom@19.1.0(react@19.2.0))(react-native-webview@13.15.0(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0))(react-native@0.83.2(@babel/core@7.28.6)(@react-native-community/cli@20.1.3(typescript@5.9.3))(@types/react@19.2.9)(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
 
   expo-server@55.0.6: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,5 +16,6 @@ onlyBuiltDependencies:
   - workerd
 
 patchedDependencies:
+  expo-modules-core@55.0.13: patches/expo-modules-core@55.0.13.patch
   react-native-mmkv: patches/react-native-mmkv.patch
   sonner-native@0.23.0: patches/sonner-native@0.23.0.patch

--- a/scripts/lefthook-gitleaks.cjs
+++ b/scripts/lefthook-gitleaks.cjs
@@ -1,0 +1,25 @@
+const cp = require('child_process')
+const fs = require('fs')
+
+const shell = process.platform === 'win32'
+const check = cp.spawnSync('gitleaks', ['--version'], {
+	stdio: 'ignore',
+	shell,
+})
+
+if (check.error || check.status) {
+	process.stdout.write('gitleaks is not installed, skipping secret scan\n')
+	process.exit(0)
+}
+
+const args = ['protect', '--staged', '--verbose']
+if (fs.existsSync('.gitleaks-baseline.json')) {
+	args.push('--baseline-path', '.gitleaks-baseline.json')
+}
+
+const result = cp.spawnSync('gitleaks', args, {
+	stdio: 'inherit',
+	shell,
+})
+
+process.exit(result.status ?? 1)


### PR DESCRIPTION
## Summary
- Add an LLM-powered smart shuffle flow for local playlists, including playlist entry points, modal UI, app-store flags, navigation typing, and persistent track tag storage.
- Add the smart shuffle tagging service and database migration so tracks can be classified with tags, confidence, and optional reasoning for recommendation/shuffle decisions.
- Improve development reliability on Windows and Expo prebuild by using `cross-env`, fixing generated Android ABI filter insertion, and making Lefthook/gitleaks execution work without fragile inline shell parsing.

## Feature Details
- Adds `SmartShuffleModal` and `LlmSmartShuffleSettingsModal` so users can start smart shuffle from playlist UI and configure the feature from playback settings.
- Introduces `LlmSmartShuffleService` plus `TrackTagIndex` storage to normalize LLM responses, clamp confidence values, persist tags, and support future smart ordering logic.
- Extends the local playlist header and playlist screen wiring so the feature is available where users manage/play local playlists.
- Adds Drizzle migration `0019_smart_shuffle_tags` and schema updates for smart shuffle tag indexing.
- Updates Bilibili playlist sync integration to work with the new smart shuffle metadata path.

## Tooling / Android Notes
- Fixes `withAbiFilters` so Expo prebuild inserts `ndk.abiFilters` into `defaultConfig` safely without corrupting `buildConfigField` in `android/app/build.gradle`.
- Adds `cross-env` to mobile scripts so `expo start` and `expo run:android` work consistently on Windows shells.
- Updates Lefthook gitleaks handling with a small Node wrapper so pre-commit hooks do not fail from shell parsing differences on Windows.

## Verification
- Confirmed working tree is clean before pushing.
- Confirmed branch diff against `origin/dev` contains the intended smart shuffle, Android prebuild, and tooling changes.
- Previously verified generated Android Gradle project with `./gradlew.bat projects` from `apps/mobile/android` successfully.
- Pre-commit and commit-msg hooks passed while creating the latest commits; gitleaks is skipped locally because it is not installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **新功能**
  * 智能随机播放：用户可通过自然语言提示语自定义播放队列
  * LLM配置界面：支持配置OpenAI兼容API端点和默认收听偏好
  * 智能标签索引：自动为播放列表曲目生成和存储AI标签

* **改进**
  * 增强跨平台构建脚本兼容性

* **Chores**
  * 更新代码检查脚本配置

<!-- end of auto-generated comment: release notes by coderabbit.ai -->