### PR TITLE
harden: fix security issue in update-server.ts

### DIFF
--- a/apps/hot-update-cli/src/services/update-server.ts
+++ b/apps/hot-update-cli/src/services/update-server.ts
@@ -99,6 +99,15 @@ export async function getUpdateServerCredentials(
 	if (!serverUrl || !accessToken) {
 		throw new Error('--server and --token are required')
 	}
+	const serverUrlProtocol = new URL(serverUrl).protocol
+	const isLocalhost = /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/.test(
+		serverUrl,
+	)
+	if (serverUrlProtocol !== 'https:' && !isLocalhost) {
+		throw new Error(
+			'--server must use https:// to avoid transmitting the bearer token in plaintext',
+		)
+	}
 
 	const credentials = {
 		serverUrl: serverUrl.replace(/\/$/, ''),


### PR DESCRIPTION
## Summary
Harden input handling in `apps/hot-update-cli/src/services/update-server.ts` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `apps/hot-update-cli/src/services/update-server.ts:75` |
| **Assessment** | Defensive hardening |

**Description**: The update server CLI tool relies on client-side credential storage with directory permissions (0o700/0o600) as the primary security control. Bearer tokens are transmitted without mandatory HTTPS enforcement, mutual TLS, or certificate pinning. An attacker obtaining the credentials file through malware, backup extraction, or social engineering can replay tokens to authenticate as a legitimate publisher.

## Threat Model Context

This is a private Node.js application (not published to npm). Vulnerabilities affect this application's own runtime only.

## Changes
- `apps/hot-update-cli/src/services/update-server.ts`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-002 scanner=multi_agent_ai -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **安全性改进**
  - 更新服务器地址现已进行协议校验。
  - 仅允许 `localhost` 和 `127.0.0.1` 使用 HTTP；其他服务器地址必须使用 HTTPS。
  - 使用不符合要求的地址时，系统将提示错误并拒绝连接。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->