### PR TITLE
mobile: add DLNA speaker casting

### DIFF
--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -12,6 +12,7 @@
 		"test:backup": "NODE_OPTIONS=--experimental-vm-modules jest --config jest.webdav.config.cjs --runInBand && jest --config jest.backup.config.cjs"
 	},
 	"dependencies": {
+		"@bbplayer/dlna": "workspace:*",
 		"@bbplayer/heatmap": "workspace:*",
 		"@bbplayer/image-theme-colors": "workspace:*",
 		"@bbplayer/logs": "workspace:*",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -18,11 +18,13 @@ import { Toaster } from 'sonner-native'
 
 import AnimatedBootSplash from '@/components/AnimatedBootSplash'
 import { alert } from '@/components/modals/AlertModal'
+import DlnaCastModal from '@/components/modals/DlnaCastModal'
 import PlayerQueueModal from '@/components/modals/PlayerQueueModal'
 import AppProviders from '@/components/providers'
 import { useFeatureTracking } from '@/hooks/analytics/useFeatureTracking'
 import useCheckUpdate from '@/hooks/app/useCheckUpdate'
 import { useFastMigrations } from '@/hooks/app/useFastMigrations'
+import { DlnaPlaybackSync } from '@/hooks/player/useDlnaPlaybackSync'
 import { serializeCookieObject } from '@/hooks/stores/useAppStore'
 import useAppStoreObj from '@/hooks/stores/useAppStore'
 import { initPlayerQueueStore } from '@/hooks/stores/usePlayerQueueStore'
@@ -384,6 +386,8 @@ function RootLayout() {
 				) : null}
 				<Toaster />
 				<PlayerQueueModal />
+				<DlnaCastModal />
+				<DlnaPlaybackSync />
 			</AppProviders>
 			<AnimatedBootSplash ready={isReady && migrationsSuccess} />
 		</View>

--- a/apps/mobile/src/app/player.tsx
+++ b/apps/mobile/src/app/player.tsx
@@ -141,6 +141,7 @@ export default function PlayerPage() {
 	}
 
 	const gradientColors = useDerivedValue(() => {
+		'worklet'
 		if (playerBackgroundStyle !== 'gradient') {
 			return [colors.background, colors.background]
 		}

--- a/apps/mobile/src/components/NowPlayingBar.tsx
+++ b/apps/mobile/src/components/NowPlayingBar.tsx
@@ -2,7 +2,6 @@ import {
 	Orpheus,
 	PlaybackState,
 	useAdjacentTracks,
-	useIsPlaying,
 	usePlaybackState,
 } from '@bbplayer/orpheus'
 import { Image } from 'expo-image'
@@ -27,10 +26,16 @@ import Animated, {
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { scheduleOnRN } from 'react-native-worklets'
 
+import {
+	skipWithDlna,
+	toggleDlnaOrLocal,
+} from '@/features/player/dlna/castCurrentTrack'
 import useCurrentTrack from '@/hooks/player/useCurrentTrack'
+import useEffectiveIsPlaying from '@/hooks/player/useEffectiveIsPlaying'
 import useSmoothProgress from '@/hooks/player/useSmoothProgress'
 import { useBottomTabBarHeight } from '@/hooks/router/useBottomTabBarHeight'
 import useAppStore from '@/hooks/stores/useAppStore'
+import { useDlnaCastStore } from '@/hooks/stores/useDlnaCastStore'
 import { usePlayerQueueSheetStore } from '@/hooks/stores/usePlayerQueueSheetStore'
 import * as Haptics from '@/utils/haptics'
 import { resolveTrackCover } from '@/utils/imageUrl'
@@ -45,6 +50,7 @@ const ProgressBar = memo(function ProgressBar() {
 	const { colors } = useTheme()
 
 	const animatedStyle = useAnimatedStyle(() => {
+		'worklet'
 		const progressRatio = Math.min(
 			sharedProgress.value / Math.max(sharedDuration.value, 1),
 			1,
@@ -88,12 +94,11 @@ const ProgressBar = memo(function ProgressBar() {
 
 const playPause = async () => {
 	void Haptics.performHaptics(Haptics.AndroidHaptics.Context_Click)
-	const isPlaying = await Orpheus.getIsPlaying()
-	if (isPlaying) {
-		void Orpheus.pause()
-	} else {
-		await Orpheus.play()
-	}
+	const casting = !!useDlnaCastStore.getState().castingDevice
+	const isPlaying = casting
+		? useDlnaCastStore.getState().playing
+		: await Orpheus.getIsPlaying()
+	await toggleDlnaOrLocal(isPlaying)
 }
 
 const NowPlayingBar = memo(function NowPlayingBar({
@@ -102,17 +107,17 @@ const NowPlayingBar = memo(function NowPlayingBar({
 	backgroundColor?: string
 }) {
 	const { colors } = useTheme()
-	const isPlaying = useIsPlaying()
+	const isPlaying = useEffectiveIsPlaying()
 	const state = usePlaybackState()
+	const transportState = useDlnaCastStore((s) => s.transportState)
+	const casting = useDlnaCastStore((s) => !!s.castingDevice)
 	const currentTrack = useCurrentTrack()
 	const router = useRouter()
 	const insets = useSafeAreaInsets()
 	const isVisible = currentTrack !== null
 	const bottomBarHeight = useBottomTabBarHeight()
 
-	const nowPlayingBarStyle = useAppStore(
-		(s) => s.settings.nowPlayingBarStyle,
-	)
+	const nowPlayingBarStyle = useAppStore((s) => s.settings.nowPlayingBarStyle)
 
 	const finalPlayingIndicator = isPlaying ? 'pause' : 'play'
 
@@ -136,17 +141,26 @@ const NowPlayingBar = memo(function NowPlayingBar({
 	const dragOffset = useSharedValue(0)
 	const hapticFired = useSharedValue(0)
 
-	const normalOpacity = useAnimatedStyle(() => ({
-		opacity: 1 - Math.min(Math.abs(dragOffset.value) / 40, 1),
-	}))
+	const normalOpacity = useAnimatedStyle(() => {
+		'worklet'
+		return {
+			opacity: 1 - Math.min(Math.abs(dragOffset.value) / 40, 1),
+		}
+	})
 
-	const prevIndicatorOpacity = useAnimatedStyle(() => ({
-		opacity: Math.min(Math.max(dragOffset.value / 40, 0), 1),
-	}))
+	const prevIndicatorOpacity = useAnimatedStyle(() => {
+		'worklet'
+		return {
+			opacity: Math.min(Math.max(dragOffset.value / 40, 0), 1),
+		}
+	})
 
-	const nextIndicatorOpacity = useAnimatedStyle(() => ({
-		opacity: Math.min(Math.max(-dragOffset.value / 40, 0), 1),
-	}))
+	const nextIndicatorOpacity = useAnimatedStyle(() => {
+		'worklet'
+		return {
+			opacity: Math.min(Math.max(-dragOffset.value / 40, 0), 1),
+		}
+	})
 
 	const navigateOnPlayerUpFling = useFlingGesture({
 		direction: Directions.UP,
@@ -194,9 +208,9 @@ const NowPlayingBar = memo(function NowPlayingBar({
 		onDeactivate: () => {
 			'worklet'
 			if (dragOffset.value > SWIPE_THRESHOLD && hasPrevSv.value) {
-				scheduleOnRN(() => void Orpheus.skipToPrevious())
+				scheduleOnRN(() => void skipWithDlna('prev'))
 			} else if (dragOffset.value < -SWIPE_THRESHOLD && hasNextSv.value) {
-				scheduleOnRN(() => void Orpheus.skipToNext())
+				scheduleOnRN(() => void skipWithDlna('next'))
 			}
 			dragOffset.set(withTiming(0))
 			hapticFired.set(0)
@@ -370,7 +384,11 @@ const NowPlayingBar = memo(function NowPlayingBar({
 									style={styles.nowPlayingBarControlButton}
 									onPress={() => playPause()}
 								>
-									{state === PlaybackState.BUFFERING ? (
+									{(
+										casting
+											? transportState === 'TRANSITIONING'
+											: state === PlaybackState.BUFFERING
+									) ? (
 										<ActivityIndicator size='small' />
 									) : (
 										<Icon

--- a/apps/mobile/src/components/modals/DlnaCastModal.tsx
+++ b/apps/mobile/src/components/modals/DlnaCastModal.tsx
@@ -1,0 +1,188 @@
+import {
+	castToDlna,
+	discoverDlnaDevices,
+	type DlnaDevice,
+} from '@bbplayer/dlna'
+import { Orpheus } from '@bbplayer/orpheus'
+import { TrueSheet } from '@lodev09/react-native-true-sheet'
+import { useCallback, useState } from 'react'
+import { Platform, View } from 'react-native'
+import { ActivityIndicator, List, Text, useTheme } from 'react-native-paper'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
+
+import IconButton from '@/components/common/IconButton'
+import { disconnectDlnaCast } from '@/features/player/dlna/castCurrentTrack'
+import { resolveCastSource } from '@/features/player/dlna/resolveCastSource'
+import useCurrentTrack from '@/hooks/player/useCurrentTrack'
+import { useDlnaCastSheetStore } from '@/hooks/stores/useDlnaCastSheetStore'
+import { useDlnaCastStore } from '@/hooks/stores/useDlnaCastStore'
+import { toastAndLogError } from '@/utils/error-handling'
+import * as Haptics from '@/utils/haptics'
+import toast from '@/utils/toast'
+
+export default function DlnaCastModal() {
+	const theme = useTheme()
+	const insets = useSafeAreaInsets()
+	const currentTrack = useCurrentTrack()
+	const castingDevice = useDlnaCastStore((s) => s.castingDevice)
+	const castingTitle = useDlnaCastStore((s) => s.castingTitle)
+	const [devices, setDevices] = useState<DlnaDevice[]>([])
+	const [discovering, setDiscovering] = useState(false)
+	const [casting, setCasting] = useState(false)
+
+	const refresh = useCallback(async () => {
+		if (Platform.OS !== 'android') {
+			toast.info('DLNA 投屏目前只支持 Android')
+			return
+		}
+		setDiscovering(true)
+		try {
+			const found = await discoverDlnaDevices(3500)
+			setDevices(found)
+			if (found.length === 0) {
+				toast.info('没有发现 DLNA 设备', {
+					description: '确认音箱和手机在同一 Wi-Fi',
+				})
+			}
+		} catch (e) {
+			toastAndLogError('搜索 DLNA 设备失败', e, 'UI.Player.Dlna')
+		} finally {
+			setDiscovering(false)
+		}
+	}, [])
+
+	const handleCast = useCallback(
+		async (device: DlnaDevice) => {
+			if (!currentTrack) {
+				toast.error('当前没有在播的歌曲')
+				return
+			}
+			setCasting(true)
+			try {
+				const source = await resolveCastSource(currentTrack)
+				await Orpheus.pause()
+				await castToDlna({
+					controlURL: device.controlURL,
+					renderingControlURL: device.renderingControlURL ?? undefined,
+					title: source.title,
+					mime: source.mime,
+					sourceUrl: source.sourceUrl,
+					filePath: source.filePath,
+					headers: source.headers,
+				})
+				useDlnaCastStore.getState().setCasting(device, source.title)
+				void Haptics.performHaptics(Haptics.AndroidHaptics.Confirm)
+				toast.success(`已投屏到 ${device.name}`)
+				void useDlnaCastSheetStore.getState().close()
+			} catch (e) {
+				toastAndLogError('投屏失败', e, 'UI.Player.Dlna')
+			} finally {
+				setCasting(false)
+			}
+		},
+		[currentTrack],
+	)
+
+	const handleStop = useCallback(async () => {
+		setCasting(true)
+		try {
+			await disconnectDlnaCast()
+			void Haptics.performHaptics(Haptics.AndroidHaptics.Confirm)
+			toast.success('已停止投屏')
+			void useDlnaCastSheetStore.getState().close()
+		} catch (e) {
+			toastAndLogError('停止投屏失败', e, 'UI.Player.Dlna')
+		} finally {
+			setCasting(false)
+		}
+	}, [])
+
+	const visibleDevices =
+		castingDevice &&
+		!devices.some((d) => d.controlURL === castingDevice.controlURL)
+			? [castingDevice, ...devices]
+			: devices
+
+	return (
+		<TrueSheet
+			name='dlnaCastModal'
+			detents={['auto']}
+			cornerRadius={24}
+			backgroundColor={theme.colors.elevation.level1}
+			onDidPresent={() => {
+				useDlnaCastSheetStore.getState().setOpen(true)
+				void refresh()
+			}}
+			onDidDismiss={() => {
+				useDlnaCastSheetStore.getState().setOpen(false)
+			}}
+		>
+			<View
+				style={{
+					paddingTop: 16,
+					paddingBottom: insets.bottom + 20,
+				}}
+			>
+				<View
+					style={{
+						flexDirection: 'row',
+						alignItems: 'center',
+						justifyContent: 'space-between',
+						paddingHorizontal: 20,
+						marginBottom: 8,
+					}}
+				>
+					<Text variant='titleMedium'>投屏到音箱</Text>
+					<IconButton
+						icon='refresh'
+						size={22}
+						disabled={discovering || casting}
+						onPress={() => void refresh()}
+					/>
+				</View>
+				{discovering && visibleDevices.length === 0 ? (
+					<View style={{ paddingVertical: 24, alignItems: 'center' }}>
+						<ActivityIndicator />
+						<Text
+							variant='bodySmall'
+							style={{ marginTop: 8, color: theme.colors.onSurfaceVariant }}
+						>
+							正在搜索局域网设备…
+						</Text>
+					</View>
+				) : (
+					visibleDevices.map((device) => {
+						const connected = castingDevice?.controlURL === device.controlURL
+						return (
+							<List.Item
+								key={device.udn ?? device.controlURL}
+								title={device.name}
+								description={
+									connected
+										? `点击断开${castingTitle ? ` · ${castingTitle}` : ''}`
+										: [device.manufacturer, device.model]
+												.filter(Boolean)
+												.join(' · ')
+								}
+								disabled={casting}
+								left={(props) => (
+									<List.Icon
+										{...props}
+										icon={connected ? 'cast-connected' : 'cast'}
+									/>
+								)}
+								onPress={() => {
+									if (connected) {
+										void handleStop()
+										return
+									}
+									void handleCast(device)
+								}}
+							/>
+						)
+					})
+				)}
+			</View>
+		</TrueSheet>
+	)
+}

--- a/apps/mobile/src/components/modals/DlnaCastModal.tsx
+++ b/apps/mobile/src/components/modals/DlnaCastModal.tsx
@@ -1,9 +1,4 @@
-import {
-	castToDlna,
-	discoverDlnaDevices,
-	type DlnaDevice,
-} from '@bbplayer/dlna'
-import { Orpheus } from '@bbplayer/orpheus'
+import { discoverDlnaDevices, type DlnaDevice } from '@bbplayer/dlna'
 import { TrueSheet } from '@lodev09/react-native-true-sheet'
 import { useCallback, useState } from 'react'
 import { Platform, View } from 'react-native'
@@ -11,7 +6,10 @@ import { ActivityIndicator, List, Text, useTheme } from 'react-native-paper'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import IconButton from '@/components/common/IconButton'
-import { disconnectDlnaCast } from '@/features/player/dlna/castCurrentTrack'
+import {
+	disconnectDlnaCast,
+	playSourceOnDevice,
+} from '@/features/player/dlna/castCurrentTrack'
 import { resolveCastSource } from '@/features/player/dlna/resolveCastSource'
 import useCurrentTrack from '@/hooks/player/useCurrentTrack'
 import { useDlnaCastSheetStore } from '@/hooks/stores/useDlnaCastSheetStore'
@@ -60,17 +58,7 @@ export default function DlnaCastModal() {
 			setCasting(true)
 			try {
 				const source = await resolveCastSource(currentTrack)
-				await Orpheus.pause()
-				await castToDlna({
-					controlURL: device.controlURL,
-					renderingControlURL: device.renderingControlURL ?? undefined,
-					title: source.title,
-					mime: source.mime,
-					sourceUrl: source.sourceUrl,
-					filePath: source.filePath,
-					headers: source.headers,
-				})
-				useDlnaCastStore.getState().setCasting(device, source.title)
+				await playSourceOnDevice(device, source, true)
 				void Haptics.performHaptics(Haptics.AndroidHaptics.Confirm)
 				toast.success(`已投屏到 ${device.name}`)
 				void useDlnaCastSheetStore.getState().close()

--- a/apps/mobile/src/components/modals/PlayerQueueModal.tsx
+++ b/apps/mobile/src/components/modals/PlayerQueueModal.tsx
@@ -20,6 +20,7 @@ import { Surface, Text, useTheme } from 'react-native-paper'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 
 import IconButton from '@/components/common/IconButton'
+import { skipWithDlna } from '@/features/player/dlna/castCurrentTrack'
 import useCurrentTrackIdHook from '@/hooks/player/useCurrentTrackId'
 import { useIsCurrentTrack } from '@/hooks/player/useIsCurrentTrack'
 import { useShuffleMode } from '@/hooks/queries/orpheus'
@@ -131,7 +132,7 @@ function PlayerQueueModal({ sheetRef, ...props }: PlayerQueueModalProps) {
 			const target = queue[index]
 			if (!target) return
 			if (target.id === currentTrackId) return
-			await Orpheus.skipTo(index)
+			await skipWithDlna(index)
 		},
 		[queue, currentTrackId],
 	)

--- a/apps/mobile/src/features/player/components/PlayerControls.tsx
+++ b/apps/mobile/src/features/player/components/PlayerControls.tsx
@@ -2,7 +2,6 @@ import {
 	Orpheus,
 	PlaybackState,
 	RepeatMode,
-	useIsPlaying,
 	usePlaybackState,
 } from '@bbplayer/orpheus'
 import { useRouter } from 'expo-router'
@@ -14,8 +13,15 @@ import { useTheme } from 'react-native-paper'
 
 import ActivityIndicator from '@/components/common/ActivityIndicator'
 import IconButton from '@/components/common/IconButton'
+import {
+	skipWithDlna,
+	toggleDlnaOrLocal,
+} from '@/features/player/dlna/castCurrentTrack'
 import useCurrentTrack from '@/hooks/player/useCurrentTrack'
+import useEffectiveIsPlaying from '@/hooks/player/useEffectiveIsPlaying'
 import { useShuffleMode } from '@/hooks/queries/orpheus'
+import { useDlnaCastSheetStore } from '@/hooks/stores/useDlnaCastSheetStore'
+import { useDlnaCastStore } from '@/hooks/stores/useDlnaCastStore'
 import { analyticsService } from '@/lib/services/analyticsService'
 import { toastAndLogError } from '@/utils/error-handling'
 import * as Haptics from '@/utils/haptics'
@@ -42,8 +48,10 @@ export function MainPlaybackControls({
 	onInteraction,
 }: MainPlaybackControlsProps) {
 	const { colors } = useTheme()
-	const isPlaying = useIsPlaying()
+	const isPlaying = useEffectiveIsPlaying()
 	const state = usePlaybackState()
+	const transportState = useDlnaCastStore((s) => s.transportState)
+	const casting = useDlnaCastStore((s) => !!s.castingDevice)
 
 	// 对 isPlaying 状态添加防抖，避免 seek 时短暂闪烁图标
 	const [debouncedIsPlaying, setDebouncedIsPlaying] = useState(isPlaying)
@@ -57,7 +65,10 @@ export function MainPlaybackControls({
 	const isFirstMount = useRef(true)
 
 	useEffect(() => {
-		if (state === PlaybackState.BUFFERING) {
+		const buffering = casting
+			? transportState === 'TRANSITIONING'
+			: state === PlaybackState.BUFFERING
+		if (buffering) {
 			if (bufferingTimeoutRef.current) {
 				clearTimeout(bufferingTimeoutRef.current)
 				bufferingTimeoutRef.current = null
@@ -77,7 +88,7 @@ export function MainPlaybackControls({
 				clearTimeout(bufferingTimeoutRef.current)
 			}
 		}
-	}, [state])
+	}, [casting, state, transportState])
 
 	useEffect(() => {
 		if (playingTimeoutRef.current) {
@@ -151,7 +162,7 @@ export function MainPlaybackControls({
 					onInteraction?.()
 					void Haptics.performHaptics(Haptics.AndroidHaptics.Context_Click)
 					prevLottieRef.current?.play(0, 60)
-					void Orpheus.skipToPrevious()
+					void skipWithDlna('prev')
 					void analyticsService.logPlayerAction('skip_prev')
 				}}
 				testID='player-prev'
@@ -182,13 +193,10 @@ export function MainPlaybackControls({
 					setDebouncedIsPlaying(nextIsPlaying)
 
 					try {
-						if (debouncedIsPlaying) {
-							await Orpheus.pause()
-							void analyticsService.logPlayerAction('pause')
-						} else {
-							await Orpheus.play()
-							void analyticsService.logPlayerAction('play')
-						}
+						await toggleDlnaOrLocal(debouncedIsPlaying)
+						void analyticsService.logPlayerAction(
+							debouncedIsPlaying ? 'pause' : 'play',
+						)
 					} catch (e) {
 						toastAndLogError('播放操作失败', e, 'UI.Player.Controls')
 					}
@@ -224,7 +232,7 @@ export function MainPlaybackControls({
 					onInteraction?.()
 					void Haptics.performHaptics(Haptics.AndroidHaptics.Context_Click)
 					nextLottieRef.current?.play(0, 60)
-					void Orpheus.skipToNext()
+					void skipWithDlna('next')
 					void analyticsService.logPlayerAction('skip_next')
 				}}
 				testID='player-next'
@@ -248,6 +256,7 @@ export function PlayerControls({ onOpenQueue }: { onOpenQueue: () => void }) {
 	const [repeatMode, setRepeatMode] = useState(RepeatMode.OFF)
 	const currentTrack = useCurrentTrack()
 	const router = useRouter()
+	const castingDevice = useDlnaCastStore((s) => s.castingDevice)
 
 	useEffect(() => {
 		void Orpheus.getRepeatMode().then(setRepeatMode)
@@ -328,6 +337,16 @@ export function PlayerControls({ onOpenQueue }: { onOpenQueue: () => void }) {
 					testID='player-open-comments'
 				/>
 				<IconButton
+					icon={castingDevice ? 'cast-connected' : 'cast'}
+					size={24}
+					iconColor={castingDevice ? colors.primary : colors.onSurfaceVariant}
+					onPress={() => {
+						void Haptics.performHaptics(Haptics.AndroidHaptics.Context_Click)
+						void useDlnaCastSheetStore.getState().open()
+					}}
+					testID='player-open-dlna'
+				/>
+				<IconButton
 					icon='format-list-bulleted'
 					size={24}
 					iconColor={colors.onSurfaceVariant}
@@ -357,6 +376,6 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		alignItems: 'center',
 		justifyContent: 'center',
-		gap: 32,
+		gap: 20,
 	},
 })

--- a/apps/mobile/src/features/player/components/PlayerLyrics.tsx
+++ b/apps/mobile/src/features/player/components/PlayerLyrics.tsx
@@ -102,6 +102,7 @@ const Lyrics = memo(function Lyrics({
 	}, [tempOffset, offsetSharedValue])
 
 	const adjustedCurrentTime = useDerivedValue(() => {
+		'worklet'
 		return currentTime.value - offsetSharedValue.value
 	})
 

--- a/apps/mobile/src/features/player/components/PlayerSlider.tsx
+++ b/apps/mobile/src/features/player/components/PlayerSlider.tsx
@@ -142,11 +142,16 @@ export function PlayerSlider({ onInteraction }: PlayerSliderProps = {}) {
 			isSeeking.set(true)
 			if (useDlnaCastStore.getState().castingDevice) {
 				useDlnaCastStore.getState().setPlayback({ position: time })
-				void seekDlnaCast(time).then(() => {
-					position.set(time)
-					isSeeking.set(false)
-					seekTimeoutRef.current = null
-				})
+				void seekDlnaCast(time)
+					.then(() => {
+						position.set(time)
+						isSeeking.set(false)
+						seekTimeoutRef.current = null
+					})
+					.catch(() => {
+						isSeeking.set(false)
+						seekTimeoutRef.current = null
+					})
 				return
 			}
 			void Orpheus.seekTo(time)

--- a/apps/mobile/src/features/player/components/PlayerSlider.tsx
+++ b/apps/mobile/src/features/player/components/PlayerSlider.tsx
@@ -1,7 +1,8 @@
-import { Orpheus, useIsPlaying } from '@bbplayer/orpheus'
+import { seekDlnaCast } from '@bbplayer/dlna'
+import { Orpheus } from '@bbplayer/orpheus'
 import Color from 'color'
 import { WavySlider } from 'expo-wavy-slider'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { memo, useCallback, useMemo, useRef } from 'react'
 import { StyleSheet, View } from 'react-native'
 import AnimateableText from 'react-native-animateable-text'
 import { useTheme } from 'react-native-paper'
@@ -16,12 +17,13 @@ import {
 import { scheduleOnRN } from 'react-native-worklets'
 
 import useSmoothProgress from '@/hooks/player/useSmoothProgress'
+import { useDlnaCastStore } from '@/hooks/stores/useDlnaCastStore'
 import useSkinStore from '@/hooks/stores/useSkinStore'
 import useActiveSkin from '@/hooks/theme/useActiveSkin'
 import * as Haptics from '@/utils/haptics'
 import { formatDurationToHHMMSS } from '@/utils/time'
 
-function TextWithAnimation({
+const TextWithAnimation = memo(function TextWithAnimation({
 	sharedPosition,
 	sharedDuration,
 }: {
@@ -34,8 +36,12 @@ function TextWithAnimation({
 	const durationText = useSharedValue('00:00')
 
 	useAnimatedReaction(
-		() => (sharedPosition.value ? Math.trunc(sharedPosition.value) : 0),
+		() => {
+			'worklet'
+			return sharedPosition.value ? Math.trunc(sharedPosition.value) : 0
+		},
 		(pos, prev) => {
+			'worklet'
 			if (pos !== prev) {
 				positionText.value = formatDurationToHHMMSS(pos)
 			}
@@ -43,8 +49,12 @@ function TextWithAnimation({
 	)
 
 	useAnimatedReaction(
-		() => (sharedDuration.value ? Math.trunc(sharedDuration.value) : 0),
+		() => {
+			'worklet'
+			return sharedDuration.value ? Math.trunc(sharedDuration.value) : 0
+		},
 		(dur, prev) => {
+			'worklet'
 			if (dur !== prev) {
 				durationText.value = formatDurationToHHMMSS(dur)
 			}
@@ -61,11 +71,13 @@ function TextWithAnimation({
 		[colors.onSurfaceVariant, fonts.bodySmall],
 	)
 	const positionTextProp = useAnimatedProps(() => {
+		'worklet'
 		return {
 			text: positionText.value,
 		}
 	})
 	const durationTextProp = useAnimatedProps(() => {
+		'worklet'
 		return {
 			text: durationText.value,
 		}
@@ -87,7 +99,7 @@ function TextWithAnimation({
 			/>
 		</>
 	)
-}
+})
 
 interface PlayerSliderProps {
 	onInteraction?: () => void
@@ -106,29 +118,37 @@ export function PlayerSlider({ onInteraction }: PlayerSliderProps = {}) {
 		(state) => state.skinSliderThumbOffsetY ?? 0,
 	)
 	const activePlayIconIndex = useSkinStore((state) => state.activePlayIconIndex)
-	const { position, duration, buffered } = useSmoothProgress()
-	const isPlaying = useIsPlaying()
+	const {
+		position,
+		duration,
+		buffered,
+		isPlaying: isPlayingShared,
+	} = useSmoothProgress()
 
 	const isScrubbing = useSharedValue(false)
 	const scrubPosition = useSharedValue(0)
 	const isSeeking = useSharedValue(false)
 	const seekPosition = useSharedValue(0)
-	const isPlayingShared = useSharedValue(isPlaying)
 	const isNativeDragging = useSharedValue(false)
-	const animatedWaveHeight = useSharedValue(isPlaying ? 6 : 0)
-	const animatedWaveVelocity = useSharedValue(isPlaying ? 15 : 0)
+	const animatedWaveHeight = useSharedValue(0)
+	const animatedWaveVelocity = useSharedValue(0)
 	const animatedWaveThickness = useSharedValue(3)
 	const animatedTrackThickness = useSharedValue(3)
 	const seekTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-	useEffect(() => {
-		isPlayingShared.set(isPlaying)
-	}, [isPlaying, isPlayingShared])
 
 	const handleSeek = useCallback(
 		(time: number) => {
 			if (seekTimeoutRef.current) clearTimeout(seekTimeoutRef.current)
 			isSeeking.set(true)
+			if (useDlnaCastStore.getState().castingDevice) {
+				useDlnaCastStore.getState().setPlayback({ position: time })
+				void seekDlnaCast(time).then(() => {
+					position.set(time)
+					isSeeking.set(false)
+					seekTimeoutRef.current = null
+				})
+				return
+			}
 			void Orpheus.seekTo(time)
 
 			seekTimeoutRef.current = setTimeout(() => {
@@ -145,14 +165,19 @@ export function PlayerSlider({ onInteraction }: PlayerSliderProps = {}) {
 	)
 
 	const displayPosition = useDerivedValue(() => {
+		'worklet'
 		if (isScrubbing.value) return scrubPosition.value
 		if (isSeeking.value) return seekPosition.value
 		return position.value
 	})
 
 	useAnimatedReaction(
-		() => position.value,
+		() => {
+			'worklet'
+			return position.value
+		},
 		(currentPosition) => {
+			'worklet'
 			if (!isSeeking.value) return
 			const target = seekPosition.value
 			const threshold = 1
@@ -165,12 +190,15 @@ export function PlayerSlider({ onInteraction }: PlayerSliderProps = {}) {
 	)
 
 	useAnimatedReaction(
-		() =>
-			[
+		() => {
+			'worklet'
+			return [
 				isPlayingShared.value,
 				isNativeDragging.value || isScrubbing.value,
-			] as const,
+			] as const
+		},
 		([playing, dragging]) => {
+			'worklet'
 			const shouldShowWave = playing && !dragging
 			const thickness = dragging ? 12 : 3
 			animatedWaveHeight.set(
@@ -194,6 +222,7 @@ export function PlayerSlider({ onInteraction }: PlayerSliderProps = {}) {
 	)
 
 	const progressFraction = useDerivedValue(() => {
+		'worklet'
 		const dur = duration.value || 1
 		let pos = position.value
 		if (isScrubbing.value) {
@@ -206,6 +235,7 @@ export function PlayerSlider({ onInteraction }: PlayerSliderProps = {}) {
 
 	// oxlint-disable-next-line no-underscore-dangle
 	const _bufferedFraction = useDerivedValue(() => {
+		'worklet'
 		const dur = duration.value || 1
 		return Math.min(Math.max(buffered.value / dur, 0), 1)
 	})

--- a/apps/mobile/src/features/player/components/PlayerTrackInfo.tsx
+++ b/apps/mobile/src/features/player/components/PlayerTrackInfo.tsx
@@ -1,4 +1,4 @@
-import { useIsPlaying, useSpectrumVisualizerEnabled } from '@bbplayer/orpheus'
+import { useSpectrumVisualizerEnabled } from '@bbplayer/orpheus'
 import type { ImageRef } from 'expo-image'
 import { Image } from 'expo-image'
 import { LinearGradient } from 'expo-linear-gradient'
@@ -17,6 +17,7 @@ import { Text, TouchableRipple, useTheme } from 'react-native-paper'
 import IconButton from '@/components/common/IconButton'
 import { useThumbUpVideo } from '@/hooks/mutations/bilibili/video'
 import useCurrentTrack from '@/hooks/player/useCurrentTrack'
+import useEffectiveIsPlaying from '@/hooks/player/useEffectiveIsPlaying'
 import { useGetVideoIsThumbUp } from '@/hooks/queries/bilibili/video'
 import useActiveSkin from '@/hooks/theme/useActiveSkin'
 import { getGradientColors } from '@/utils/color'
@@ -42,7 +43,7 @@ export function TrackInfo({
 	const isDark: boolean = colorScheme === 'dark'
 
 	const currentTrack = useCurrentTrack()
-	const isPlaying = useIsPlaying()
+	const isPlaying = useEffectiveIsPlaying()
 	const [isTitleExpanded, setIsTitleExpanded] = useState(false)
 	const [thumbUpBurstSignal, setThumbUpBurstSignal] = useState(0)
 	const activeSkin = useActiveSkin()

--- a/apps/mobile/src/features/player/components/SpectrumVisualizer.tsx
+++ b/apps/mobile/src/features/player/components/SpectrumVisualizer.tsx
@@ -40,6 +40,7 @@ export const SpectrumVisualizer = ({
 	}, [])
 
 	const geometry = useDerivedValue(() => {
+		'worklet'
 		const center = size / 2 + MAX_BAR_HEIGHT
 		const radius = size / 2 + GAP
 		const result = new Float32Array(BAR_COUNT * 4)
@@ -55,6 +56,7 @@ export const SpectrumVisualizer = ({
 	}, [size])
 
 	const path = useDerivedValue(() => {
+		'worklet'
 		const skPath = Skia.Path.Make()
 		const geo = geometry.value
 		const freq = frequencyData.value

--- a/apps/mobile/src/features/player/components/lyrics/KaraokeWord.tsx
+++ b/apps/mobile/src/features/player/components/lyrics/KaraokeWord.tsx
@@ -33,7 +33,10 @@ export const KaraokeWord = memo(function KaraokeWord({
 	const layoutWidth = useSharedValue(0)
 
 	useAnimatedReaction(
-		() => currentTime.value,
+		() => {
+			'worklet'
+			return currentTime.value
+		},
 		(currentVal: number) => {
 			const timeMs = currentVal * 1000
 			if (timeMs < span.startTime) {
@@ -55,6 +58,7 @@ export const KaraokeWord = memo(function KaraokeWord({
 	)
 
 	const maskStyle = useAnimatedStyle(() => {
+		'worklet'
 		return {
 			width: layoutWidth.value * localProgress.value,
 			opacity: currentTime.value >= 0 ? 1 : 0,
@@ -62,6 +66,7 @@ export const KaraokeWord = memo(function KaraokeWord({
 	})
 
 	const activeTextStyle = useAnimatedStyle(() => {
+		'worklet'
 		return {
 			width: layoutWidth.value,
 			color: activeColor,

--- a/apps/mobile/src/features/player/components/lyrics/LyricLineItem.tsx
+++ b/apps/mobile/src/features/player/components/lyrics/LyricLineItem.tsx
@@ -26,11 +26,13 @@ function useLyricColor(
 	enabled = true,
 ) {
 	const progress = useDerivedValue(() => {
+		'worklet'
 		const target = isHighlighted.value && enabled ? 1 : 0
 		return immediate ? target : withTiming(target, { duration: 300 })
 	})
 
 	return useDerivedValue(() => {
+		'worklet'
 		// Keep invalid animation progress away from native color props.
 		if (!Number.isFinite(progress.value)) {
 			return isHighlighted.value && enabled ? activeColor : inactiveColor
@@ -67,10 +69,12 @@ export const OldSchoolLyricLineItem = memo(function OldSchoolLyricLineItem({
 	const colors = useTheme().colors
 
 	const isHighlighted = useDerivedValue(() => {
+		'worklet'
 		return currentHighlightIndex.value === index
 	})
 
 	const gatedCurrentTime = useDerivedValue(() => {
+		'worklet'
 		return isHighlighted.value ? currentTime.value : -1
 	})
 
@@ -88,6 +92,7 @@ export const OldSchoolLyricLineItem = memo(function OldSchoolLyricLineItem({
 	)
 
 	const animatedStyle = useAnimatedStyle(() => {
+		'worklet'
 		const duration = isVerbatim ? 0 : 300
 		if (isHighlighted.value) {
 			return {
@@ -168,6 +173,7 @@ export const ModernLyricLineItem = memo(function ModernLyricLineItem({
 	const theme = useTheme()
 
 	const isHighlighted = useDerivedValue(() => {
+		'worklet'
 		return currentHighlightIndex.value === index
 	})
 
@@ -175,7 +181,10 @@ export const ModernLyricLineItem = memo(function ModernLyricLineItem({
 	const [isHighlightedRState, setIsHighlightedRState] = useState(false)
 
 	useAnimatedReaction(
-		() => currentHighlightIndex.value,
+		() => {
+			'worklet'
+			return currentHighlightIndex.value
+		},
 		(currentVal) => {
 			scheduleOnRN(
 				setIsVerbatim,
@@ -190,6 +199,7 @@ export const ModernLyricLineItem = memo(function ModernLyricLineItem({
 	)
 
 	const containerAnimatedStyle = useAnimatedStyle(() => {
+		'worklet'
 		if (isHighlighted.value) {
 			return {
 				opacity: withTiming(1, { duration: 300 }),
@@ -216,9 +226,12 @@ export const ModernLyricLineItem = memo(function ModernLyricLineItem({
 		theme.colors.onSurfaceDisabled,
 		isHighlightedRState,
 	)
-	const textAnimatedStyle = useAnimatedStyle(() => ({
-		color: lyricColor.value,
-	}))
+	const textAnimatedStyle = useAnimatedStyle(() => {
+		'worklet'
+		return {
+			color: lyricColor.value,
+		}
+	})
 
 	const renderContent = () => {
 		if (isVerbatim) {

--- a/apps/mobile/src/features/player/dlna/castCurrentTrack.ts
+++ b/apps/mobile/src/features/player/dlna/castCurrentTrack.ts
@@ -3,10 +3,14 @@ import {
 	pauseDlnaCast,
 	resumeDlnaCast,
 	stopDlnaCast,
+	type DlnaDevice,
 } from '@bbplayer/dlna'
 import { Orpheus } from '@bbplayer/orpheus'
 
-import { resolveCastSource } from '@/features/player/dlna/resolveCastSource'
+import {
+	resolveCastSource,
+	type ResolvedCastSource,
+} from '@/features/player/dlna/resolveCastSource'
 import { useDlnaCastStore } from '@/hooks/stores/useDlnaCastStore'
 import { trackService } from '@/lib/services/trackService'
 import log from '@/utils/log'
@@ -14,6 +18,7 @@ import log from '@/utils/log'
 const logger = log.extend('Player.Dlna')
 
 let recasting = false
+let recastQueued = false
 let disconnecting = false
 
 export function isDlnaRecasting() {
@@ -47,18 +52,13 @@ export async function disconnectDlnaCast() {
 	}
 }
 
-export async function recastCurrentTrack() {
-	const device = useDlnaCastStore.getState().castingDevice
-	if (!device || recasting || disconnecting) return
-
-	recasting = true
+export async function playSourceOnDevice(
+	device: DlnaDevice,
+	source: ResolvedCastSource,
+	resumeLocalOnFail: boolean,
+) {
+	await Orpheus.pause()
 	try {
-		const uniqueKey = (await Orpheus.getCurrentTrack())?.id
-		if (!uniqueKey) throw new Error('当前没有在播的歌曲')
-		const result = await trackService.getTrackByUniqueKey(uniqueKey)
-		if (result.isErr()) throw result.error
-		const source = await resolveCastSource(result.value)
-		await Orpheus.pause()
 		await castToDlna({
 			controlURL: device.controlURL,
 			renderingControlURL: device.renderingControlURL ?? undefined,
@@ -69,11 +69,41 @@ export async function recastCurrentTrack() {
 			headers: source.headers,
 		})
 		useDlnaCastStore.getState().setCasting(device, source.title)
-		logger.info('已切到音箱', { title: source.title })
+	} catch (e) {
+		if (resumeLocalOnFail) {
+			try {
+				await Orpheus.play()
+			} catch (playError) {
+				logger.warning('投屏失败后恢复本地播放失败', { error: playError })
+			}
+		}
+		throw e
+	}
+}
+
+export async function recastCurrentTrack() {
+	if (!useDlnaCastStore.getState().castingDevice || disconnecting) return
+	if (recasting) {
+		recastQueued = true
+		return
+	}
+
+	recasting = true
+	try {
+		do {
+			recastQueued = false
+			const device = useDlnaCastStore.getState().castingDevice
+			if (!device || disconnecting) return
+			const uniqueKey = (await Orpheus.getCurrentTrack())?.id
+			if (!uniqueKey) throw new Error('当前没有在播的歌曲')
+			const result = await trackService.getTrackByUniqueKey(uniqueKey)
+			if (result.isErr()) throw result.error
+			const source = await resolveCastSource(result.value)
+			await playSourceOnDevice(device, source, false)
+			logger.info('已切到音箱', { title: source.title })
+		} while (recastQueued && useDlnaCastStore.getState().castingDevice)
 	} finally {
-		setTimeout(() => {
-			recasting = false
-		}, 2500)
+		recasting = false
 	}
 }
 

--- a/apps/mobile/src/features/player/dlna/castCurrentTrack.ts
+++ b/apps/mobile/src/features/player/dlna/castCurrentTrack.ts
@@ -1,0 +1,113 @@
+import {
+	castToDlna,
+	pauseDlnaCast,
+	resumeDlnaCast,
+	stopDlnaCast,
+} from '@bbplayer/dlna'
+import { Orpheus } from '@bbplayer/orpheus'
+
+import { resolveCastSource } from '@/features/player/dlna/resolveCastSource'
+import { useDlnaCastStore } from '@/hooks/stores/useDlnaCastStore'
+import { trackService } from '@/lib/services/trackService'
+import log from '@/utils/log'
+
+const logger = log.extend('Player.Dlna')
+
+let recasting = false
+let disconnecting = false
+
+export function isDlnaRecasting() {
+	return recasting
+}
+
+export function isDlnaDisconnecting() {
+	return disconnecting
+}
+
+export async function disconnectDlnaCast() {
+	const { castingDevice, position, playing } = useDlnaCastStore.getState()
+	if (!castingDevice || disconnecting) return
+
+	disconnecting = true
+	try {
+		await stopDlnaCast()
+		useDlnaCastStore.getState().setCasting(null)
+	} catch (e) {
+		logger.warning('停止音箱失败', { error: e })
+		throw e
+	} finally {
+		disconnecting = false
+	}
+
+	try {
+		if (position > 0.5) await Orpheus.seekTo(position)
+		if (playing) await Orpheus.play()
+	} catch (e) {
+		logger.warning('恢复本地播放失败', { error: e })
+	}
+}
+
+export async function recastCurrentTrack() {
+	const device = useDlnaCastStore.getState().castingDevice
+	if (!device || recasting || disconnecting) return
+
+	recasting = true
+	try {
+		const uniqueKey = (await Orpheus.getCurrentTrack())?.id
+		if (!uniqueKey) throw new Error('当前没有在播的歌曲')
+		const result = await trackService.getTrackByUniqueKey(uniqueKey)
+		if (result.isErr()) throw result.error
+		const source = await resolveCastSource(result.value)
+		await Orpheus.pause()
+		await castToDlna({
+			controlURL: device.controlURL,
+			renderingControlURL: device.renderingControlURL ?? undefined,
+			title: source.title,
+			mime: source.mime,
+			sourceUrl: source.sourceUrl,
+			filePath: source.filePath,
+			headers: source.headers,
+		})
+		useDlnaCastStore.getState().setCasting(device, source.title)
+		logger.info('已切到音箱', { title: source.title })
+	} finally {
+		setTimeout(() => {
+			recasting = false
+		}, 2500)
+	}
+}
+
+export async function skipWithDlna(action: 'next' | 'prev' | number) {
+	if (typeof action === 'number') {
+		await Orpheus.skipTo(action)
+		return
+	}
+	if (action === 'next') {
+		await Orpheus.skipToNext()
+		return
+	}
+	await Orpheus.skipToPrevious()
+}
+
+export async function toggleDlnaOrLocal(isPlaying: boolean) {
+	if (useDlnaCastStore.getState().castingDevice) {
+		if (isPlaying) {
+			await pauseDlnaCast()
+			useDlnaCastStore.getState().setPlayback({
+				playing: false,
+				transportState: 'PAUSED_PLAYBACK',
+			})
+		} else {
+			await resumeDlnaCast()
+			useDlnaCastStore
+				.getState()
+				.setPlayback({ playing: true, transportState: 'PLAYING' })
+		}
+		return
+	}
+	if (isPlaying) {
+		await Orpheus.pause()
+	} else {
+		await Orpheus.play()
+	}
+}

--- a/apps/mobile/src/features/player/dlna/resolveCastSource.ts
+++ b/apps/mobile/src/features/player/dlna/resolveCastSource.ts
@@ -1,0 +1,88 @@
+import useAppStore, { serializeCookieObject } from '@/hooks/stores/useAppStore'
+import { bilibiliApi } from '@/lib/api/bilibili/api'
+import type { Track } from '@/types/core/media'
+import { returnOrThrowAsync } from '@/utils/neverthrow-utils'
+
+/** 与 Orpheus 拉 B 站音频相同，音箱走本地代理时必须带上 */
+const BILIBILI_STREAM_HEADERS = {
+	Referer: 'https://www.bilibili.com/',
+	'User-Agent':
+		'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+}
+
+export interface ResolvedCastSource {
+	title: string
+	mime: string
+	sourceUrl?: string
+	filePath?: string
+	headers?: Record<string, string>
+}
+
+const guessMime = (path: string) => {
+	const ext = path.split('?')[0].split('.').pop()?.toLowerCase()
+	switch (ext) {
+		case 'mp3':
+			return 'audio/mpeg'
+		case 'm4a':
+		case 'mp4':
+			return 'audio/mp4'
+		case 'aac':
+			return 'audio/aac'
+		case 'flac':
+			return 'audio/flac'
+		case 'wav':
+			return 'audio/wav'
+		default:
+			return 'audio/mp4'
+	}
+}
+
+export async function resolveCastSource(
+	track: Track,
+): Promise<ResolvedCastSource> {
+	if (track.source === 'local' && track.localMetadata) {
+		return {
+			title: track.title,
+			filePath: track.localMetadata.localPath,
+			mime: guessMime(track.localMetadata.localPath),
+		}
+	}
+
+	if (track.source !== 'bilibili') {
+		throw new Error('当前曲目不支持投屏')
+	}
+
+	let cid = track.bilibiliMetadata.cid
+	if (!cid) {
+		const pages = await returnOrThrowAsync(
+			bilibiliApi.getPageList({ bvid: track.bilibiliMetadata.bvid }),
+		)
+		cid = pages[0]?.cid
+	}
+	if (!cid) {
+		throw new Error('无法获取音频 cid')
+	}
+
+	const stream = await returnOrThrowAsync(
+		bilibiliApi.getAudioStream({
+			bvid: track.bilibiliMetadata.bvid,
+			cid,
+			audioQuality: 30280,
+			enableDolby: false,
+			enableHiRes: false,
+		}),
+	)
+
+	const cookie = useAppStore.getState().bilibiliCookie
+	const cookieHeader = cookie ? serializeCookieObject(cookie) : undefined
+
+	return {
+		title: track.title,
+		sourceUrl: stream.url,
+		headers: {
+			...BILIBILI_STREAM_HEADERS,
+			...(cookieHeader ? { Cookie: cookieHeader } : {}),
+		},
+		mime: stream.type === 'local' ? guessMime(stream.url) : 'audio/mp4',
+	}
+}

--- a/apps/mobile/src/features/player/hooks/useLyricSync.ts
+++ b/apps/mobile/src/features/player/hooks/useLyricSync.ts
@@ -1,3 +1,4 @@
+import { seekDlnaCast } from '@bbplayer/dlna'
 import { Orpheus } from '@bbplayer/orpheus'
 import type { LyricLine } from '@bbplayer/splash'
 import { useCallback, useEffect, useRef } from 'react'
@@ -5,6 +6,7 @@ import { AppState } from 'react-native'
 import { useAnimatedReaction, useSharedValue } from 'react-native-reanimated'
 import { scheduleOnRN } from 'react-native-worklets'
 
+import { useDlnaCastStore } from '@/hooks/stores/useDlnaCastStore'
 import playerProgressEmitter from '@/lib/player/progressListener'
 
 export default function useLyricSync(
@@ -48,7 +50,13 @@ export default function useLyricSync(
 			if (lyrics.length === 0) return
 			if (!lyrics[index]) return
 			const requestId = ++latestJumpRequestRef.current
-			await Orpheus.seekTo(lyrics[index].startTime / 1000 - offset)
+			const target = lyrics[index].startTime / 1000 - offset
+			if (useDlnaCastStore.getState().castingDevice) {
+				useDlnaCastStore.getState().setPlayback({ position: target })
+				await seekDlnaCast(target)
+			} else {
+				await Orpheus.seekTo(target)
+			}
 			if (latestJumpRequestRef.current !== requestId) return
 			if (manualScrollTimeoutRef.current) {
 				clearTimeout(manualScrollTimeoutRef.current)
@@ -84,7 +92,10 @@ export default function useLyricSync(
 
 	// ponytail: animated reaction to scroll on index change without React state
 	useAnimatedReaction(
-		() => currentLyricIndex.value,
+		() => {
+			'worklet'
+			return currentLyricIndex.value
+		},
 		(index, prevIndex) => {
 			if (index === prevIndex) return
 			if (!enabled) return
@@ -98,28 +109,43 @@ export default function useLyricSync(
 		const appStateSub = AppState.addEventListener('change', (nextAppState) => {
 			isActiveRef.current = nextAppState === 'active'
 		})
-		const handler = playerProgressEmitter.subscribe('progress', (data) => {
+		const applyPosition = (raw: number) => {
 			if (!enabled) return
-
-			const offsetedPosition = data.position + offset
+			const offsetedPosition = raw + offset
 			if (!isActiveRef.current || offsetedPosition <= 0) return
-			const index = findIndexForTime(offsetedPosition)
-			currentLyricIndex.set(index)
+			currentLyricIndex.set(findIndexForTime(offsetedPosition))
+		}
+
+		const handler = playerProgressEmitter.subscribe('progress', (data) => {
+			if (useDlnaCastStore.getState().castingDevice) return
+			applyPosition(data.position)
+		})
+		const dlnaUnsub = useDlnaCastStore.subscribe((s) => {
+			if (!s.castingDevice) return
+			applyPosition(s.position)
 		})
 		return () => {
 			handler()
+			dlnaUnsub()
 			appStateSub.remove()
 		}
 	}, [enabled, findIndexForTime, offset, currentLyricIndex])
 
 	useEffect(() => {
 		if (!enabled) return
-		void Orpheus.getPosition().then((data) => {
+		const raw = useDlnaCastStore.getState().castingDevice
+			? useDlnaCastStore.getState().position
+			: undefined
+		const apply = (data: number) => {
 			const offsetedPosition = data + offset
 			if (!isActiveRef.current || offsetedPosition <= 0) return
-			const index = findIndexForTime(offsetedPosition)
-			currentLyricIndex.set(index)
-		})
+			currentLyricIndex.set(findIndexForTime(offsetedPosition))
+		}
+		if (raw !== undefined) {
+			apply(raw)
+			return
+		}
+		void Orpheus.getPosition().then(apply)
 	}, [enabled, findIndexForTime, offset, currentLyricIndex])
 
 	useEffect(() => {

--- a/apps/mobile/src/features/player/hooks/usePlayerHeaderAnimation.ts
+++ b/apps/mobile/src/features/player/hooks/usePlayerHeaderAnimation.ts
@@ -10,6 +10,7 @@ export function usePlayerHeaderAnimation(
 	scrollX?: SharedValue<number>,
 ) {
 	const titleStyle = useAnimatedStyle(() => {
+		'worklet'
 		if (!scrollX) return { opacity: index === 1 ? 1 : 0 }
 		return {
 			opacity: interpolate(
@@ -22,6 +23,7 @@ export function usePlayerHeaderAnimation(
 	})
 
 	const statusStyle = useAnimatedStyle(() => {
+		'worklet'
 		if (!scrollX) return { opacity: index === 0 ? 1 : 0 }
 		return {
 			opacity: interpolate(

--- a/apps/mobile/src/hooks/player/useDlnaPlaybackSync.ts
+++ b/apps/mobile/src/hooks/player/useDlnaPlaybackSync.ts
@@ -1,0 +1,102 @@
+import { getDlnaStatus } from '@bbplayer/dlna'
+import { Orpheus } from '@bbplayer/orpheus'
+import { useEffect, useRef } from 'react'
+
+import {
+	isDlnaDisconnecting,
+	isDlnaRecasting,
+	recastCurrentTrack,
+	skipWithDlna,
+} from '@/features/player/dlna/castCurrentTrack'
+import { useDlnaCastStore } from '@/hooks/stores/useDlnaCastStore'
+import log from '@/utils/log'
+
+const logger = log.extend('Player.DlnaSync')
+
+export default function useDlnaPlaybackSync() {
+	const casting = useDlnaCastStore((s) => !!s.castingDevice)
+	const sawPlayingRef = useRef(false)
+	const lastPositionRef = useRef(0)
+	const advancingRef = useRef(false)
+
+	useEffect(() => {
+		if (!casting) {
+			sawPlayingRef.current = false
+			lastPositionRef.current = 0
+			advancingRef.current = false
+			return
+		}
+
+		let cancelled = false
+
+		const trackSub = Orpheus.addListener('onTrackStarted', () => {
+			void recastCurrentTrack().catch((e) => {
+				logger.warning('投屏切歌失败', { error: e })
+			})
+		})
+
+		const tick = async () => {
+			try {
+				if (isDlnaRecasting() || isDlnaDisconnecting()) return
+				const status = await getDlnaStatus()
+				if (cancelled || isDlnaDisconnecting() || !status) return
+
+				const playing = status.state === 'PLAYING'
+				if (playing) sawPlayingRef.current = true
+
+				useDlnaCastStore.getState().setPlayback({
+					playing,
+					position: status.position,
+					duration: status.duration,
+					transportState: status.state,
+				})
+
+				const atEnd =
+					status.duration > 1 &&
+					(status.position >= status.duration - 1.5 ||
+						lastPositionRef.current >= status.duration - 1.5)
+				const stopped =
+					status.state === 'STOPPED' || status.state === 'NO_MEDIA_PRESENT'
+				const ended =
+					sawPlayingRef.current &&
+					!isDlnaRecasting() &&
+					(atEnd ||
+						(stopped && lastPositionRef.current > 8 && status.position < 2)) &&
+					(stopped || status.state === 'PAUSED_PLAYBACK' || (playing && atEnd))
+
+				lastPositionRef.current = status.position
+
+				if (cancelled || isDlnaDisconnecting()) return
+
+				if (ended && !advancingRef.current) {
+					advancingRef.current = true
+					sawPlayingRef.current = false
+					try {
+						await skipWithDlna('next')
+					} catch (e) {
+						logger.warning('投屏自动切歌失败', { error: e })
+					} finally {
+						advancingRef.current = false
+					}
+				}
+			} catch (e) {
+				if (!cancelled) {
+					logger.debug('读取音箱状态失败', { error: e })
+				}
+			}
+		}
+
+		void tick()
+		const id = setInterval(() => void tick(), 1000)
+		return () => {
+			cancelled = true
+			clearInterval(id)
+			trackSub.remove()
+		}
+	}, [casting])
+}
+
+export function DlnaPlaybackSync() {
+	useDlnaPlaybackSync()
+	return null
+}

--- a/apps/mobile/src/hooks/player/useDlnaPlaybackSync.ts
+++ b/apps/mobile/src/hooks/player/useDlnaPlaybackSync.ts
@@ -28,6 +28,7 @@ export default function useDlnaPlaybackSync() {
 		}
 
 		let cancelled = false
+		let inFlight = false
 
 		const trackSub = Orpheus.addListener('onTrackStarted', () => {
 			void recastCurrentTrack().catch((e) => {
@@ -36,10 +37,13 @@ export default function useDlnaPlaybackSync() {
 		})
 
 		const tick = async () => {
+			if (inFlight) return
+			inFlight = true
 			try {
 				if (isDlnaRecasting() || isDlnaDisconnecting()) return
 				const status = await getDlnaStatus()
-				if (cancelled || isDlnaDisconnecting() || !status) return
+				if (cancelled || isDlnaDisconnecting() || isDlnaRecasting() || !status)
+					return
 
 				const playing = status.state === 'PLAYING'
 				if (playing) sawPlayingRef.current = true
@@ -60,13 +64,13 @@ export default function useDlnaPlaybackSync() {
 				const ended =
 					sawPlayingRef.current &&
 					!isDlnaRecasting() &&
-					(atEnd ||
-						(stopped && lastPositionRef.current > 8 && status.position < 2)) &&
-					(stopped || status.state === 'PAUSED_PLAYBACK' || (playing && atEnd))
+					(stopped
+						? lastPositionRef.current > 8 && status.position < 2
+						: playing && atEnd)
 
 				lastPositionRef.current = status.position
 
-				if (cancelled || isDlnaDisconnecting()) return
+				if (cancelled || isDlnaDisconnecting() || isDlnaRecasting()) return
 
 				if (ended && !advancingRef.current) {
 					advancingRef.current = true
@@ -83,6 +87,8 @@ export default function useDlnaPlaybackSync() {
 				if (!cancelled) {
 					logger.debug('读取音箱状态失败', { error: e })
 				}
+			} finally {
+				inFlight = false
 			}
 		}
 

--- a/apps/mobile/src/hooks/player/useEffectiveIsPlaying.ts
+++ b/apps/mobile/src/hooks/player/useEffectiveIsPlaying.ts
@@ -1,0 +1,10 @@
+import { useIsPlaying } from '@bbplayer/orpheus'
+
+import { useDlnaCastStore } from '@/hooks/stores/useDlnaCastStore'
+
+export default function useEffectiveIsPlaying() {
+	const local = useIsPlaying()
+	const casting = useDlnaCastStore((s) => !!s.castingDevice)
+	const dlnaPlaying = useDlnaCastStore((s) => s.playing)
+	return casting ? dlnaPlaying : local
+}

--- a/apps/mobile/src/hooks/player/useSmoothProgress.ts
+++ b/apps/mobile/src/hooks/player/useSmoothProgress.ts
@@ -1,8 +1,13 @@
 import { Orpheus } from '@bbplayer/orpheus'
-import { useCallback, useEffect } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { AppState } from 'react-native'
-import { useFrameCallback, useSharedValue } from 'react-native-reanimated'
+import {
+	useFrameCallback,
+	useSharedValue,
+	type FrameInfo,
+} from 'react-native-reanimated'
 
+import { useDlnaCastStore } from '@/hooks/stores/useDlnaCastStore'
 import playerProgressEmitter from '@/lib/player/progressListener'
 
 /**
@@ -17,30 +22,51 @@ export default function useSmoothProgress(background = false) {
 	const isPlaying = useSharedValue(false)
 	const isAppActive = useSharedValue(true)
 
-	useFrameCallback(
-		useCallback(
-			(frameInfo) => {
-				if (
-					!isAppActive.value ||
-					!isPlaying.value ||
-					!frameInfo.timeSincePreviousFrame
-				) {
-					return
-				}
-				position.set(position.value + frameInfo.timeSincePreviousFrame / 1000)
-			},
-			[isAppActive, isPlaying, position],
-		),
+	const onFrame = useCallback(
+		(frameInfo: FrameInfo) => {
+			'worklet'
+			if (
+				!isAppActive.value ||
+				!isPlaying.value ||
+				!frameInfo.timeSincePreviousFrame
+			) {
+				return
+			}
+			position.set(position.value + frameInfo.timeSincePreviousFrame / 1000)
+		},
+		[isAppActive, isPlaying, position],
 	)
 
+	useFrameCallback(onFrame)
+
+	const lastPositionRef = useRef(0)
+	const lastPlayingRef = useRef(false)
+
 	useEffect(() => {
+		const applyDlna = () => {
+			const s = useDlnaCastStore.getState()
+			lastPositionRef.current = s.position
+			lastPlayingRef.current = s.playing
+			position.set(s.position)
+			duration.set(s.duration)
+			buffered.set(s.duration)
+			isPlaying.set(s.playing)
+		}
+
 		const syncState = () => {
+			if (useDlnaCastStore.getState().castingDevice) {
+				applyDlna()
+				return
+			}
 			void Promise.all([
 				Orpheus.getPosition(),
 				Orpheus.getDuration(),
 				Orpheus.getBuffered(),
 				Orpheus.getIsPlaying(),
 			]).then(([pos, dur, buf, playing]) => {
+				if (useDlnaCastStore.getState().castingDevice) return
+				lastPositionRef.current = pos
+				lastPlayingRef.current = playing
 				position.set(pos)
 				duration.set(dur)
 				buffered.set(buf)
@@ -49,6 +75,22 @@ export default function useSmoothProgress(background = false) {
 		}
 
 		syncState()
+
+		const dlnaUnsub = useDlnaCastStore.subscribe((s) => {
+			if (!s.castingDevice) {
+				syncState()
+				return
+			}
+			duration.set(s.duration)
+			buffered.set(s.duration)
+			lastPlayingRef.current = s.playing
+			isPlaying.set(s.playing)
+			const diff = Math.abs(lastPositionRef.current - s.position)
+			if (diff > 0.8 || !s.playing) {
+				lastPositionRef.current = s.position
+				position.set(s.position)
+			}
+		})
 
 		const appStateSub = AppState.addEventListener('change', (nextAppState) => {
 			const active = nextAppState === 'active'
@@ -59,20 +101,23 @@ export default function useSmoothProgress(background = false) {
 		})
 
 		const progressSub = playerProgressEmitter.subscribe('progress', (data) => {
+			if (useDlnaCastStore.getState().castingDevice) return
 			if (AppState.currentState !== 'active' && !background) return
 			duration.set(data.duration)
 			buffered.set(data.buffered)
-			const diff = Math.abs(position.value - data.position)
+			const diff = Math.abs(lastPositionRef.current - data.position)
 			if (
 				diff > 0.05 ||
-				!isPlaying.value ||
+				!lastPlayingRef.current ||
 				AppState.currentState !== 'active'
 			) {
+				lastPositionRef.current = data.position
 				position.set(data.position)
 			}
 		})
 
 		const stateSub = Orpheus.addListener('onPlaybackStateChanged', (_state) => {
+			if (useDlnaCastStore.getState().castingDevice) return
 			if (AppState.currentState !== 'active' && !background) return
 			syncState()
 		})
@@ -82,6 +127,8 @@ export default function useSmoothProgress(background = false) {
 		const playingSub = Orpheus.addListener(
 			'onIsPlayingChanged',
 			({ status }) => {
+				if (useDlnaCastStore.getState().castingDevice) return
+				lastPlayingRef.current = status
 				isPlaying.set(status)
 				if (AppState.currentState !== 'active' && !background) return
 				syncState()
@@ -89,6 +136,7 @@ export default function useSmoothProgress(background = false) {
 		)
 
 		return () => {
+			dlnaUnsub()
 			progressSub()
 			stateSub.remove()
 			appStateSub.remove()
@@ -97,5 +145,5 @@ export default function useSmoothProgress(background = false) {
 		}
 	}, [isPlaying, position, duration, buffered, isAppActive, background])
 
-	return { position, duration, buffered }
+	return { position, duration, buffered, isPlaying }
 }

--- a/apps/mobile/src/hooks/stores/useDlnaCastSheetStore.ts
+++ b/apps/mobile/src/hooks/stores/useDlnaCastSheetStore.ts
@@ -1,0 +1,22 @@
+import { TrueSheet } from '@lodev09/react-native-true-sheet'
+import { create } from 'zustand'
+
+interface DlnaCastSheetState {
+	isOpen: boolean
+	open: () => Promise<void>
+	close: () => Promise<void>
+	setOpen: (value: boolean) => void
+}
+
+export const useDlnaCastSheetStore = create<DlnaCastSheetState>((set) => ({
+	isOpen: false,
+	open: async () =>
+		TrueSheet.present('dlnaCastModal').catch(() => {
+			// Ignore error if view not found or already presented
+		}),
+	close: async () =>
+		TrueSheet.dismiss('dlnaCastModal').catch(() => {
+			// Ignore error if view not found or already dismissed
+		}),
+	setOpen: (value: boolean) => set({ isOpen: value }),
+}))

--- a/apps/mobile/src/hooks/stores/useDlnaCastStore.ts
+++ b/apps/mobile/src/hooks/stores/useDlnaCastStore.ts
@@ -1,0 +1,46 @@
+import type { DlnaDevice } from '@bbplayer/dlna'
+import { create } from 'zustand'
+
+interface DlnaCastState {
+	castingDevice: DlnaDevice | null
+	castingTitle: string | null
+	playing: boolean
+	position: number
+	duration: number
+	transportState: string | null
+	setCasting: (device: DlnaDevice | null, title?: string | null) => void
+	setPlayback: (
+		patch: Partial<
+			Pick<
+				DlnaCastState,
+				'playing' | 'position' | 'duration' | 'transportState'
+			>
+		>,
+	) => void
+}
+
+const idlePlayback = {
+	playing: false,
+	position: 0,
+	duration: 0,
+	transportState: null,
+}
+
+export const useDlnaCastStore = create<DlnaCastState>((set) => ({
+	castingDevice: null,
+	castingTitle: null,
+	...idlePlayback,
+	setCasting: (device, title = null) =>
+		set(
+			device
+				? {
+						castingDevice: device,
+						castingTitle: title,
+						playing: true,
+						position: 0,
+						transportState: 'TRANSITIONING',
+					}
+				: { castingDevice: null, castingTitle: null, ...idlePlayback },
+		),
+	setPlayback: (patch) => set(patch),
+}))

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -14,6 +14,7 @@
 			"@/utils/*": ["./src/utils/*"],
 			"@/features/*": ["./src/features/*"],
 			"@bbplayer/orpheus": ["../../../packages/orpheus/src/index.ts"],
+			"@bbplayer/dlna": ["../../../packages/dlna/src/index.ts"],
 			"@bbplayer/image-theme-colors": [
 				"../../../packages/image-theme-colors/src/index.ts"
 			]

--- a/packages/dlna/.gitignore
+++ b/packages/dlna/.gitignore
@@ -1,0 +1,7 @@
+.DS_Store
+node_modules/
+.expo/
+android/.gradle
+android/build
+android/.idea
+local.properties

--- a/packages/dlna/android/build.gradle
+++ b/packages/dlna/android/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+  id 'com.android.library'
+  id 'expo-module-gradle-plugin'
+}
+
+import groovy.json.JsonSlurper
+
+def packageJsonFile = new File(projectDir, '../package.json')
+def packageJson = new JsonSlurper().parseText(packageJsonFile.text)
+
+group = 'expo.modules.bbplayerdlna'
+version = packageJson.version
+
+android {
+  namespace "expo.modules.bbplayerdlna"
+  defaultConfig {
+    versionCode 1
+    versionName packageJson.version
+  }
+  lintOptions {
+    abortOnError false
+  }
+}
+
+dependencies {
+}

--- a/packages/dlna/android/src/main/AndroidManifest.xml
+++ b/packages/dlna/android/src/main/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+  <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+  <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+</manifest>

--- a/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/BBPlayerDlnaModule.kt
+++ b/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/BBPlayerDlnaModule.kt
@@ -91,10 +91,18 @@ class BBPlayerDlnaModule : Module() {
                 val url = currentControlURL
                 currentControlURL = null
                 detachVolume(requireContext())
-                if (url != null && runCatching { UpnpSoap.stop(url) }.isFailure) {
-                    runCatching { UpnpSoap.stop(url) }
+                var stopError: Throwable? = null
+                if (url != null) {
+                    val first = runCatching { UpnpSoap.stop(url) }
+                    if (first.isFailure) {
+                        val second = runCatching { UpnpSoap.stop(url) }
+                        if (second.isFailure) {
+                            stopError = second.exceptionOrNull() ?: first.exceptionOrNull()
+                        }
+                    }
                 }
                 proxy?.stop()
+                if (stopError != null) throw stopError
             }
         }
 
@@ -140,7 +148,10 @@ class BBPlayerDlnaModule : Module() {
         appContext.reactContext ?: throw IllegalStateException("React context is not available")
 
     private fun attachVolume(context: Context, renderingControlURL: String?) {
-        if (renderingControlURL.isNullOrBlank()) return
+        if (renderingControlURL.isNullOrBlank()) {
+            detachVolume(context)
+            return
+        }
         currentRenderingControlURL = renderingControlURL
         val app = context.applicationContext
         if (volumeReceiver == null) {

--- a/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/BBPlayerDlnaModule.kt
+++ b/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/BBPlayerDlnaModule.kt
@@ -1,0 +1,228 @@
+package expo.modules.bbplayerdlna
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.media.AudioManager
+import android.os.Build
+import expo.modules.kotlin.functions.Coroutine
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.records.Field
+import expo.modules.kotlin.records.Record
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class CastOptions : Record {
+    @Field
+    val controlURL: String = ""
+
+    @Field
+    val title: String = ""
+
+    @Field
+    val mime: String = "audio/mp4"
+
+    @Field
+    val sourceUrl: String? = null
+
+    @Field
+    val filePath: String? = null
+
+    @Field
+    val headersJson: String? = null
+
+    @Field
+    val renderingControlURL: String? = null
+}
+
+class BBPlayerDlnaModule : Module() {
+    private var proxy: DlnaHttpProxy? = null
+    private var currentControlURL: String? = null
+    private var currentRenderingControlURL: String? = null
+    private var volumeReceiver: BroadcastReceiver? = null
+    private var syncingVolume = false
+    private var pushingVolume = false
+    private var lastSpeakerVolume: Int? = null
+
+    override fun definition() = ModuleDefinition {
+        Name("BBPlayerDlna")
+
+        AsyncFunction("discoverAsync") Coroutine { timeoutMs: Int ->
+            val context = requireContext()
+            withContext(Dispatchers.IO) {
+                SsdpDiscovery.discover(context, timeoutMs)
+            }
+        }
+
+        AsyncFunction("castAsync") Coroutine { options: CastOptions ->
+            val context = requireContext()
+            withContext(Dispatchers.IO) {
+                if (proxy == null) {
+                    proxy = DlnaHttpProxy(context.applicationContext)
+                }
+                val source = when {
+                    !options.filePath.isNullOrBlank() && options.filePath!!.startsWith("content://") ->
+                        DlnaHttpProxy.Source.Content(options.filePath!!)
+                    !options.filePath.isNullOrBlank() ->
+                        DlnaHttpProxy.Source.LocalFile(options.filePath!!)
+                    !options.sourceUrl.isNullOrBlank() ->
+                        DlnaHttpProxy.Source.Remote(
+                            options.sourceUrl!!,
+                            parseHeaders(options.headersJson),
+                        )
+                    else -> throw IllegalArgumentException("castAsync needs sourceUrl or filePath")
+                }
+                val listenUrl = proxy!!.start(source, options.mime)
+                UpnpSoap.play(options.controlURL, listenUrl, options.title, options.mime)
+                currentControlURL = options.controlURL
+                attachVolume(context, options.renderingControlURL)
+                mapOf(
+                    "listenUrl" to listenUrl,
+                    "controlURL" to options.controlURL,
+                    "title" to options.title,
+                )
+            }
+        }
+
+        AsyncFunction("stopCastAsync") Coroutine { ->
+            withContext(Dispatchers.IO) {
+                val url = currentControlURL
+                currentControlURL = null
+                detachVolume(requireContext())
+                if (url != null && runCatching { UpnpSoap.stop(url) }.isFailure) {
+                    runCatching { UpnpSoap.stop(url) }
+                }
+                proxy?.stop()
+            }
+        }
+
+        AsyncFunction("getStatusAsync") Coroutine { ->
+            withContext(Dispatchers.IO) {
+                val url = currentControlURL ?: return@withContext null
+                val status = UpnpSoap.getStatus(url, currentRenderingControlURL)
+                val volume = status["volume"] as? Int
+                if (volume != null) {
+                    alignPhoneToSpeaker(requireContext(), volume)
+                }
+                status
+            }
+        }
+
+        AsyncFunction("pauseCastAsync") Coroutine { ->
+            withContext(Dispatchers.IO) {
+                val url = currentControlURL ?: throw IllegalStateException("Not casting")
+                UpnpSoap.pause(url)
+            }
+        }
+
+        AsyncFunction("resumeCastAsync") Coroutine { ->
+            withContext(Dispatchers.IO) {
+                val url = currentControlURL ?: throw IllegalStateException("Not casting")
+                UpnpSoap.resume(url)
+            }
+        }
+
+        AsyncFunction("seekCastAsync") Coroutine { seconds: Double ->
+            withContext(Dispatchers.IO) {
+                val url = currentControlURL ?: throw IllegalStateException("Not casting")
+                UpnpSoap.seek(url, seconds)
+            }
+        }
+
+        Function("isCasting") {
+            currentControlURL != null
+        }
+    }
+
+    private fun requireContext(): Context =
+        appContext.reactContext ?: throw IllegalStateException("React context is not available")
+
+    private fun attachVolume(context: Context, renderingControlURL: String?) {
+        if (renderingControlURL.isNullOrBlank()) return
+        currentRenderingControlURL = renderingControlURL
+        val app = context.applicationContext
+        if (volumeReceiver == null) {
+            runCatching {
+                val speaker = UpnpSoap.getVolume(renderingControlURL)
+                applyPhoneVolume(app, speaker)
+                lastSpeakerVolume = speaker
+            }
+            val receiver = object : BroadcastReceiver() {
+                override fun onReceive(ctx: Context, intent: Intent) {
+                    if (syncingVolume) return
+                    if (intent.action != "android.media.VOLUME_CHANGED_ACTION") return
+                    val stream = intent.getIntExtra("android.media.EXTRA_VOLUME_STREAM_TYPE", -1)
+                    if (stream != AudioManager.STREAM_MUSIC) return
+                    val url = currentRenderingControlURL ?: return
+                    val percent = phoneVolumePercent(ctx)
+                    pushingVolume = true
+                    Thread {
+                        try {
+                            runCatching { UpnpSoap.setVolume(url, percent) }
+                            lastSpeakerVolume = percent
+                        } finally {
+                            pushingVolume = false
+                        }
+                    }.apply { isDaemon = true; start() }
+                }
+            }
+            val filter = IntentFilter("android.media.VOLUME_CHANGED_ACTION")
+            if (Build.VERSION.SDK_INT >= 33) {
+                app.registerReceiver(receiver, filter, Context.RECEIVER_EXPORTED)
+            } else {
+                @Suppress("DEPRECATION")
+                app.registerReceiver(receiver, filter)
+            }
+            volumeReceiver = receiver
+        }
+    }
+
+    private fun detachVolume(context: Context) {
+        val receiver = volumeReceiver ?: return
+        runCatching { context.applicationContext.unregisterReceiver(receiver) }
+        volumeReceiver = null
+        currentRenderingControlURL = null
+        lastSpeakerVolume = null
+    }
+
+    private fun alignPhoneToSpeaker(context: Context, speakerVolume: Int) {
+        if (pushingVolume || lastSpeakerVolume == speakerVolume) return
+        applyPhoneVolume(context, speakerVolume)
+        lastSpeakerVolume = speakerVolume
+    }
+
+    private fun applyPhoneVolume(context: Context, percent: Int) {
+        val am = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val max = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+        if (max <= 0) return
+        val target = (percent.coerceIn(0, 100) * max + 50) / 100
+        if (am.getStreamVolume(AudioManager.STREAM_MUSIC) == target) return
+        syncingVolume = true
+        try {
+            am.setStreamVolume(AudioManager.STREAM_MUSIC, target, 0)
+        } finally {
+            syncingVolume = false
+        }
+    }
+
+    private fun phoneVolumePercent(context: Context): Int {
+        val am = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
+        val max = am.getStreamMaxVolume(AudioManager.STREAM_MUSIC)
+        if (max <= 0) return 0
+        return (am.getStreamVolume(AudioManager.STREAM_MUSIC) * 100 + max / 2) / max
+    }
+
+    private fun parseHeaders(json: String?): Map<String, String> {
+        val result = LinkedHashMap<String, String>()
+        if (json.isNullOrBlank()) return result
+        val obj = org.json.JSONObject(json)
+        val keys = obj.keys()
+        while (keys.hasNext()) {
+            val key = keys.next()
+            result[key] = obj.optString(key)
+        }
+        return result
+    }
+}

--- a/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/DlnaHttpProxy.kt
+++ b/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/DlnaHttpProxy.kt
@@ -1,0 +1,288 @@
+package expo.modules.bbplayerdlna
+
+import android.content.Context
+import android.net.Uri
+import java.io.BufferedInputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.OutputStream
+import java.net.HttpURLConnection
+import java.net.ServerSocket
+import java.net.Socket
+import java.net.URL
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class DlnaHttpProxy(private val context: Context) {
+    sealed class Source {
+        data class Remote(val url: String, val headers: Map<String, String>) : Source()
+        data class LocalFile(val path: String) : Source()
+        data class Content(val uri: String) : Source()
+    }
+
+    @Volatile
+    private var source: Source? = null
+
+    @Volatile
+    private var mime: String = "audio/mp4"
+
+    private var server: ServerSocket? = null
+    private var acceptThread: Thread? = null
+    private val running = AtomicBoolean(false)
+
+    @Synchronized
+    fun start(next: Source, nextMime: String): String {
+        source = next
+        mime = nextMime
+        if (server == null || !running.get()) {
+            val socket = ServerSocket(0)
+            server = socket
+            running.set(true)
+            acceptThread = Thread({
+                while (running.get()) {
+                    try {
+                        val client = socket.accept()
+                        Thread({ handle(client) }, "dlna-proxy-client").apply {
+                            isDaemon = true
+                            start()
+                        }
+                    } catch (_: Exception) {
+                        if (!running.get()) break
+                    }
+                }
+            }, "dlna-proxy").apply {
+                isDaemon = true
+                start()
+            }
+        }
+        val ext = extensionForMime(nextMime)
+        return "http://${LanAddress.ipv4()}:${server!!.localPort}/media-${System.currentTimeMillis()}.$ext"
+    }
+
+    @Synchronized
+    fun stop() {
+        running.set(false)
+        runCatching { server?.close() }
+        server = null
+        acceptThread = null
+        source = null
+    }
+
+    private fun handle(socket: Socket) {
+        try {
+            socket.use { client ->
+                val input = client.getInputStream().bufferedReader(Charsets.ISO_8859_1)
+                val requestLine = input.readLine() ?: return
+                val parts = requestLine.split(" ")
+                if (parts.size < 2) return
+                val method = parts[0].uppercase(Locale.US)
+                val path = parts[1]
+                val headers = LinkedHashMap<String, String>()
+                while (true) {
+                    val line = input.readLine() ?: break
+                    if (line.isEmpty()) break
+                    val idx = line.indexOf(':')
+                    if (idx > 0) {
+                        headers[line.substring(0, idx).trim().lowercase(Locale.US)] =
+                            line.substring(idx + 1).trim()
+                    }
+                }
+                val out = client.getOutputStream()
+                if (!path.startsWith("/media")) {
+                    android.util.Log.w("BBPlayerDlna", "404 $method $path")
+                    writeStatus(out, 404, "Not Found", 0)
+                    return
+                }
+                if (method != "GET" && method != "HEAD") {
+                    writeStatus(out, 405, "Method Not Allowed", 0)
+                    return
+                }
+                val range = parseRange(headers["range"])
+                serve(out, method == "HEAD", range)
+            }
+        } catch (e: Exception) {
+            android.util.Log.w("BBPlayerDlna", "client closed early: ${e.message}")
+        }
+    }
+
+    private fun serve(out: OutputStream, headOnly: Boolean, range: LongRange?) {
+        when (val src = source) {
+            is Source.Remote -> serveRemote(out, src, headOnly, range)
+            is Source.LocalFile -> serveFile(out, File(stripFileScheme(src.path)), headOnly, range)
+            is Source.Content -> serveContent(out, Uri.parse(src.uri), headOnly, range)
+            null -> writeStatus(out, 503, "No Source", 0)
+        }
+    }
+
+    private fun serveFile(out: OutputStream, file: File, headOnly: Boolean, range: LongRange?) {
+        if (!file.exists() || !file.isFile) {
+            writeStatus(out, 404, "Not Found", 0)
+            return
+        }
+        val total = file.length()
+        val (start, end, status) = resolveRange(total, range)
+        writeMediaHeaders(out, status, end - start + 1, total, start, end)
+        if (headOnly) return
+        FileInputStream(file).use { input ->
+            input.skip(start)
+            copyLimited(input, out, end - start + 1)
+        }
+    }
+
+    private fun serveContent(out: OutputStream, uri: Uri, headOnly: Boolean, range: LongRange?) {
+        val resolver = context.contentResolver
+        val total = resolver.openAssetFileDescriptor(uri, "r")?.use { it.length } ?: -1L
+        val (start, end, status) = if (total > 0) resolveRange(total, range) else Triple(0L, -1L, 200)
+        val length = if (total > 0) end - start + 1 else -1L
+        writeMediaHeaders(out, status, length, total, start, if (total > 0) end else -1L)
+        if (headOnly) return
+        resolver.openInputStream(uri)?.use { input ->
+            if (start > 0) input.skip(start)
+            if (length > 0) copyLimited(input, out, length) else input.copyTo(out)
+        }
+    }
+
+    private fun serveRemote(
+        out: OutputStream,
+        src: Source.Remote,
+        headOnly: Boolean,
+        range: LongRange?,
+    ) {
+        val conn = openUpstream(src, headOnly, range) ?: run {
+            writeStatus(out, 502, "Bad Gateway", 0)
+            return
+        }
+        try {
+            val code = conn.responseCode
+            val stream = if (code in 200..299) conn.inputStream else conn.errorStream
+            if (stream == null || code !in 200..299) {
+                android.util.Log.w("BBPlayerDlna", "upstream HTTP $code")
+                writeStatus(out, if (code > 0) code else 502, "Bad Gateway", 0)
+                return
+            }
+            val remoteLength = conn.contentLengthLong
+            val reason = if (code == 206) "Partial Content" else "OK"
+            val header = StringBuilder()
+            header.append("HTTP/1.1 ").append(code).append(' ').append(reason).append("\r\n")
+            header.append("Content-Type: ").append(mime).append("\r\n")
+            if (remoteLength >= 0) {
+                header.append("Content-Length: ").append(remoteLength).append("\r\n")
+            }
+            header.append("Accept-Ranges: bytes\r\n")
+            header.append("Connection: close\r\n")
+            header.append("transferMode.dlna.org: Streaming\r\n")
+            header.append("contentFeatures.dlna.org: DLNA.ORG_OP=01;DLNA.ORG_CI=0\r\n")
+            conn.getHeaderField("Content-Range")?.let {
+                header.append("Content-Range: ").append(it).append("\r\n")
+            }
+            header.append("\r\n")
+            out.write(header.toString().toByteArray(Charsets.US_ASCII))
+            if (!headOnly) {
+                BufferedInputStream(stream).copyTo(out)
+            }
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun openUpstream(
+        src: Source.Remote,
+        headOnly: Boolean,
+        range: LongRange?,
+    ): HttpURLConnection? {
+        var current = URL(src.url)
+        repeat(5) {
+            val conn = current.openConnection() as HttpURLConnection
+            conn.instanceFollowRedirects = false
+            conn.connectTimeout = 8000
+            conn.readTimeout = 20000
+            conn.requestMethod = if (headOnly) "HEAD" else "GET"
+            src.headers.forEach { (k, v) -> conn.setRequestProperty(k, v) }
+            if (range != null) {
+                val end = if (range.last == Long.MAX_VALUE) "" else range.last.toString()
+                conn.setRequestProperty("Range", "bytes=${range.first}-$end")
+            }
+            val code = conn.responseCode
+            if (code in 301..308) {
+                val location = conn.getHeaderField("Location")
+                conn.disconnect()
+                if (location.isNullOrBlank()) return null
+                current = URL(current, location)
+                return@repeat
+            }
+            return conn
+        }
+        return null
+    }
+
+    private fun extensionForMime(value: String): String {
+        return when {
+            value.contains("mpeg") -> "mp3"
+            value.contains("aac") && !value.contains("mp4") -> "aac"
+            else -> "m4a"
+        }
+    }
+
+    private fun writeMediaHeaders(
+        out: OutputStream,
+        status: Int,
+        length: Long,
+        total: Long,
+        start: Long,
+        end: Long,
+    ) {
+        val reason = if (status == 206) "Partial Content" else "OK"
+        val header = StringBuilder()
+        header.append("HTTP/1.1 ").append(status).append(' ').append(reason).append("\r\n")
+        header.append("Content-Type: ").append(mime).append("\r\n")
+        if (length >= 0) header.append("Content-Length: ").append(length).append("\r\n")
+        header.append("Accept-Ranges: bytes\r\n")
+        if (status == 206 && total > 0) {
+            header.append("Content-Range: bytes ").append(start).append('-').append(end)
+                .append('/').append(total).append("\r\n")
+        }
+        header.append("Connection: close\r\n")
+        header.append("transferMode.dlna.org: Streaming\r\n")
+        header.append("contentFeatures.dlna.org: DLNA.ORG_OP=01;DLNA.ORG_CI=0\r\n")
+        header.append("\r\n")
+        out.write(header.toString().toByteArray(Charsets.US_ASCII))
+    }
+
+    private fun writeStatus(out: OutputStream, code: Int, reason: String, length: Int) {
+        val header =
+            "HTTP/1.1 $code $reason\r\nContent-Length: $length\r\nConnection: close\r\n\r\n"
+        out.write(header.toByteArray(Charsets.US_ASCII))
+    }
+
+    private fun parseRange(header: String?): LongRange? {
+        if (header.isNullOrBlank() || !header.startsWith("bytes=")) return null
+        val spec = header.removePrefix("bytes=").substringBefore(',').trim()
+        val startText = spec.substringBefore('-', "")
+        val endText = spec.substringAfter('-', "")
+        val start = startText.toLongOrNull() ?: return null
+        val end = endText.toLongOrNull() ?: Long.MAX_VALUE
+        return start..end
+    }
+
+    private fun resolveRange(total: Long, range: LongRange?): Triple<Long, Long, Int> {
+        if (range == null) return Triple(0L, total - 1, 200)
+        val start = range.first.coerceAtLeast(0)
+        val end = if (range.last == Long.MAX_VALUE) total - 1 else range.last.coerceAtMost(total - 1)
+        return Triple(start, end, 206)
+    }
+
+    private fun copyLimited(input: java.io.InputStream, out: OutputStream, count: Long) {
+        var remaining = count
+        val buf = ByteArray(64 * 1024)
+        while (remaining > 0) {
+            val read = input.read(buf, 0, minOf(buf.size.toLong(), remaining).toInt())
+            if (read <= 0) break
+            out.write(buf, 0, read)
+            remaining -= read
+        }
+    }
+
+    private fun stripFileScheme(path: String): String {
+        return if (path.startsWith("file://")) Uri.parse(path).path ?: path else path
+    }
+}

--- a/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/DlnaHttpProxy.kt
+++ b/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/DlnaHttpProxy.kt
@@ -20,11 +20,9 @@ internal class DlnaHttpProxy(private val context: Context) {
         data class Content(val uri: String) : Source()
     }
 
-    @Volatile
-    private var source: Source? = null
+    private data class Session(val source: Source, val mime: String)
 
-    @Volatile
-    private var mime: String = "audio/mp4"
+    private val sessions = LinkedHashMap<String, Session>()
 
     private var server: ServerSocket? = null
     private var acceptThread: Thread? = null
@@ -32,8 +30,6 @@ internal class DlnaHttpProxy(private val context: Context) {
 
     @Synchronized
     fun start(next: Source, nextMime: String): String {
-        source = next
-        mime = nextMime
         if (server == null || !running.get()) {
             val socket = ServerSocket(0)
             server = socket
@@ -56,7 +52,12 @@ internal class DlnaHttpProxy(private val context: Context) {
             }
         }
         val ext = extensionForMime(nextMime)
-        return "http://${LanAddress.ipv4()}:${server!!.localPort}/media-${System.currentTimeMillis()}.$ext"
+        val path = "/media-${System.currentTimeMillis()}.$ext"
+        sessions[path] = Session(next, nextMime)
+        while (sessions.size > 4) {
+            sessions.remove(sessions.keys.first())
+        }
+        return "http://${LanAddress.ipv4()}:${server!!.localPort}$path"
     }
 
     @Synchronized
@@ -65,8 +66,11 @@ internal class DlnaHttpProxy(private val context: Context) {
         runCatching { server?.close() }
         server = null
         acceptThread = null
-        source = null
+        sessions.clear()
     }
+
+    @Synchronized
+    private fun sessionFor(path: String): Session? = sessions[path.substringBefore('?')]
 
     private fun handle(socket: Socket) {
         try {
@@ -88,7 +92,8 @@ internal class DlnaHttpProxy(private val context: Context) {
                     }
                 }
                 val out = client.getOutputStream()
-                if (!path.startsWith("/media")) {
+                val session = sessionFor(path)
+                if (session == null) {
                     android.util.Log.w("BBPlayerDlna", "404 $method $path")
                     writeStatus(out, 404, "Not Found", 0)
                     return
@@ -98,30 +103,42 @@ internal class DlnaHttpProxy(private val context: Context) {
                     return
                 }
                 val range = parseRange(headers["range"])
-                serve(out, method == "HEAD", range)
+                serve(out, method == "HEAD", range, session)
             }
         } catch (e: Exception) {
             android.util.Log.w("BBPlayerDlna", "client closed early: ${e.message}")
         }
     }
 
-    private fun serve(out: OutputStream, headOnly: Boolean, range: LongRange?) {
-        when (val src = source) {
-            is Source.Remote -> serveRemote(out, src, headOnly, range)
-            is Source.LocalFile -> serveFile(out, File(stripFileScheme(src.path)), headOnly, range)
-            is Source.Content -> serveContent(out, Uri.parse(src.uri), headOnly, range)
-            null -> writeStatus(out, 503, "No Source", 0)
+    private fun serve(
+        out: OutputStream,
+        headOnly: Boolean,
+        range: LongRange?,
+        session: Session,
+    ) {
+        when (val src = session.source) {
+            is Source.Remote -> serveRemote(out, src, headOnly, range, session.mime)
+            is Source.LocalFile ->
+                serveFile(out, File(stripFileScheme(src.path)), headOnly, range, session.mime)
+            is Source.Content ->
+                serveContent(out, Uri.parse(src.uri), headOnly, range, session.mime)
         }
     }
 
-    private fun serveFile(out: OutputStream, file: File, headOnly: Boolean, range: LongRange?) {
+    private fun serveFile(
+        out: OutputStream,
+        file: File,
+        headOnly: Boolean,
+        range: LongRange?,
+        mime: String,
+    ) {
         if (!file.exists() || !file.isFile) {
             writeStatus(out, 404, "Not Found", 0)
             return
         }
         val total = file.length()
         val (start, end, status) = resolveRange(total, range)
-        writeMediaHeaders(out, status, end - start + 1, total, start, end)
+        writeMediaHeaders(out, status, end - start + 1, total, start, end, mime)
         if (headOnly) return
         FileInputStream(file).use { input ->
             input.skip(start)
@@ -129,12 +146,18 @@ internal class DlnaHttpProxy(private val context: Context) {
         }
     }
 
-    private fun serveContent(out: OutputStream, uri: Uri, headOnly: Boolean, range: LongRange?) {
+    private fun serveContent(
+        out: OutputStream,
+        uri: Uri,
+        headOnly: Boolean,
+        range: LongRange?,
+        mime: String,
+    ) {
         val resolver = context.contentResolver
         val total = resolver.openAssetFileDescriptor(uri, "r")?.use { it.length } ?: -1L
         val (start, end, status) = if (total > 0) resolveRange(total, range) else Triple(0L, -1L, 200)
         val length = if (total > 0) end - start + 1 else -1L
-        writeMediaHeaders(out, status, length, total, start, if (total > 0) end else -1L)
+        writeMediaHeaders(out, status, length, total, start, if (total > 0) end else -1L, mime)
         if (headOnly) return
         resolver.openInputStream(uri)?.use { input ->
             if (start > 0) input.skip(start)
@@ -147,6 +170,7 @@ internal class DlnaHttpProxy(private val context: Context) {
         src: Source.Remote,
         headOnly: Boolean,
         range: LongRange?,
+        mime: String,
     ) {
         val conn = openUpstream(src, headOnly, range) ?: run {
             writeStatus(out, 502, "Bad Gateway", 0)
@@ -230,6 +254,7 @@ internal class DlnaHttpProxy(private val context: Context) {
         total: Long,
         start: Long,
         end: Long,
+        mime: String,
     ) {
         val reason = if (status == 206) "Partial Content" else "OK"
         val header = StringBuilder()

--- a/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/LanAddress.kt
+++ b/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/LanAddress.kt
@@ -1,0 +1,21 @@
+package expo.modules.bbplayerdlna
+
+import java.net.Inet4Address
+import java.net.NetworkInterface
+
+internal object LanAddress {
+    fun ipv4(): String {
+        val interfaces = NetworkInterface.getNetworkInterfaces() ?: return "127.0.0.1"
+        for (nif in interfaces) {
+            if (!nif.isUp || nif.isLoopback) continue
+            val addresses = nif.inetAddresses
+            while (addresses.hasMoreElements()) {
+                val addr = addresses.nextElement()
+                if (addr is Inet4Address && addr.isSiteLocalAddress) {
+                    return addr.hostAddress ?: continue
+                }
+            }
+        }
+        return "127.0.0.1"
+    }
+}

--- a/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/SsdpDiscovery.kt
+++ b/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/SsdpDiscovery.kt
@@ -1,0 +1,175 @@
+package expo.modules.bbplayerdlna
+
+import android.content.Context
+import android.net.wifi.WifiManager
+import android.util.Xml
+import java.io.StringReader
+import java.net.DatagramPacket
+import java.net.DatagramSocket
+import java.net.InetAddress
+import java.net.SocketTimeoutException
+import java.net.URL
+import java.nio.charset.StandardCharsets
+import org.xmlpull.v1.XmlPullParser
+
+internal object SsdpDiscovery {
+    private val SEARCH_TARGETS = arrayOf(
+        "urn:schemas-upnp-org:device:MediaRenderer:1",
+        "upnp:rootdevice",
+    )
+
+    fun discover(context: Context, timeoutMs: Int): List<Map<String, String?>> {
+        val wifi = context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
+        val lock = wifi.createMulticastLock("bbplayer-dlna")
+        lock.setReferenceCounted(false)
+        lock.acquire()
+        val locations = LinkedHashSet<String>()
+        try {
+            DatagramSocket().use { socket ->
+                socket.broadcast = true
+                socket.reuseAddress = true
+                socket.soTimeout = 400
+                val group = InetAddress.getByName("239.255.255.250")
+                for (st in SEARCH_TARGETS) {
+                    val bytes = msearch(st)
+                    socket.send(DatagramPacket(bytes, bytes.size, group, 1900))
+                }
+                val deadline = System.currentTimeMillis() + timeoutMs.coerceAtLeast(800)
+                val buf = ByteArray(4096)
+                while (System.currentTimeMillis() < deadline) {
+                    try {
+                        val packet = DatagramPacket(buf, buf.size)
+                        socket.receive(packet)
+                        val text = String(packet.data, 0, packet.length, StandardCharsets.UTF_8)
+                        val location = header(text, "location") ?: continue
+                        locations.add(location.trim())
+                    } catch (_: SocketTimeoutException) {
+                    }
+                }
+            }
+        } finally {
+            if (lock.isHeld) lock.release()
+        }
+
+        val devices = LinkedHashMap<String, Map<String, String?>>()
+        for (location in locations) {
+            val device = runCatching { fetchDevice(location) }.getOrNull() ?: continue
+            val key = device["udn"] ?: device["controlURL"] ?: location
+            devices[key] = device
+        }
+        return devices.values.toList()
+    }
+
+    private fun msearch(st: String): ByteArray {
+        val body = listOf(
+            "M-SEARCH * HTTP/1.1",
+            "HOST: 239.255.255.250:1900",
+            "MAN: \"ssdp:discover\"",
+            "MX: 2",
+            "ST: $st",
+            "",
+            "",
+        ).joinToString("\r\n")
+        return body.toByteArray(StandardCharsets.UTF_8)
+    }
+
+    private fun header(response: String, name: String): String? {
+        val prefix = "$name:"
+        return response.lineSequence()
+            .map { it.trim() }
+            .firstOrNull { it.startsWith(prefix, ignoreCase = true) }
+            ?.substring(prefix.length)
+            ?.trim()
+    }
+
+    private fun fetchDevice(location: String): Map<String, String?>? {
+        val xml = URL(location).readText()
+        val parsed = parseDescription(xml, location) ?: return null
+        if (parsed["controlURL"].isNullOrBlank()) return null
+        return parsed
+    }
+
+    private fun parseDescription(xml: String, location: String): Map<String, String?>? {
+        val parser = Xml.newPullParser()
+        parser.setInput(StringReader(xml))
+        val base = URL(location)
+        var event = parser.eventType
+        var friendlyName: String? = null
+        var manufacturer: String? = null
+        var modelName: String? = null
+        var udn: String? = null
+        var deviceType: String? = null
+        var currentServiceType: String? = null
+        var avTransport: String? = null
+        var renderingControl: String? = null
+        var depthDevice = 0
+        var inService = false
+
+        while (event != XmlPullParser.END_DOCUMENT) {
+            when (event) {
+                XmlPullParser.START_TAG -> {
+                    when (parser.name) {
+                        "device" -> depthDevice++
+                        "service" -> inService = true
+                        "friendlyName" -> if (depthDevice == 1 && friendlyName == null) {
+                            friendlyName = parser.nextText()
+                        }
+                        "manufacturer" -> if (depthDevice == 1 && manufacturer == null) {
+                            manufacturer = parser.nextText()
+                        }
+                        "modelName" -> if (depthDevice == 1 && modelName == null) {
+                            modelName = parser.nextText()
+                        }
+                        "UDN" -> if (depthDevice == 1 && udn == null) {
+                            udn = parser.nextText()
+                        }
+                        "deviceType" -> if (depthDevice == 1 && deviceType == null) {
+                            deviceType = parser.nextText()
+                        }
+                        "serviceType" -> if (inService) {
+                            currentServiceType = parser.nextText()
+                        }
+                        "controlURL" -> if (inService) {
+                            val path = parser.nextText().trim()
+                            val absolute = resolve(base, path)
+                            when {
+                                currentServiceType?.contains("AVTransport") == true ->
+                                    avTransport = absolute
+                                currentServiceType?.contains("RenderingControl") == true ->
+                                    renderingControl = absolute
+                            }
+                        }
+                    }
+                }
+                XmlPullParser.END_TAG -> {
+                    when (parser.name) {
+                        "device" -> depthDevice--
+                        "service" -> {
+                            inService = false
+                            currentServiceType = null
+                        }
+                    }
+                }
+            }
+            event = parser.next()
+        }
+
+        val isRenderer = deviceType?.contains("MediaRenderer") == true || avTransport != null
+        if (!isRenderer || avTransport == null) return null
+
+        return mapOf(
+            "name" to (friendlyName ?: "DLNA 设备"),
+            "location" to location,
+            "controlURL" to avTransport,
+            "renderingControlURL" to renderingControl,
+            "udn" to udn,
+            "manufacturer" to manufacturer,
+            "model" to modelName,
+        )
+    }
+
+    private fun resolve(base: URL, path: String): String {
+        if (path.startsWith("http://") || path.startsWith("https://")) return path
+        return URL(base, path).toString()
+    }
+}

--- a/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/UpnpSoap.kt
+++ b/packages/dlna/android/src/main/java/expo/modules/bbplayerdlna/UpnpSoap.kt
@@ -1,0 +1,160 @@
+package expo.modules.bbplayerdlna
+
+import java.net.HttpURLConnection
+import java.net.URL
+
+internal object UpnpSoap {
+    private const val AV = "urn:schemas-upnp-org:service:AVTransport:1"
+    private const val RC = "urn:schemas-upnp-org:service:RenderingControl:1"
+
+    @Synchronized
+    fun play(controlURL: String, mediaUrl: String, title: String, mime: String) {
+        runCatching { soap(controlURL, AV, "Stop", "<InstanceID>0</InstanceID>") }
+        Thread.sleep(400)
+        val didl = didl(mediaUrl, title, mime)
+        soap(
+            controlURL,
+            AV,
+            "SetAVTransportURI",
+            "<InstanceID>0</InstanceID>" +
+                "<CurrentURI>${escape(mediaUrl)}</CurrentURI>" +
+                "<CurrentURIMetaData>${escape(didl)}</CurrentURIMetaData>",
+        )
+        soap(controlURL, AV, "Play", "<InstanceID>0</InstanceID><Speed>1</Speed>")
+    }
+
+    @Synchronized
+    fun stop(controlURL: String) {
+        soap(controlURL, AV, "Stop", "<InstanceID>0</InstanceID>")
+    }
+
+    @Synchronized
+    fun pause(controlURL: String) {
+        soap(controlURL, AV, "Pause", "<InstanceID>0</InstanceID>")
+    }
+
+    @Synchronized
+    fun resume(controlURL: String) {
+        soap(controlURL, AV, "Play", "<InstanceID>0</InstanceID><Speed>1</Speed>")
+    }
+
+    @Synchronized
+    fun seek(controlURL: String, seconds: Double) {
+        soap(
+            controlURL,
+            AV,
+            "Seek",
+            "<InstanceID>0</InstanceID><Unit>REL_TIME</Unit><Target>${secondsToHms(seconds)}</Target>",
+        )
+    }
+
+    @Synchronized
+    fun getStatus(controlURL: String, renderingControlURL: String? = null): Map<String, Any> {
+        val transport = soap(controlURL, AV, "GetTransportInfo", "<InstanceID>0</InstanceID>")
+        val position = soap(controlURL, AV, "GetPositionInfo", "<InstanceID>0</InstanceID>")
+        val state = parseTag(transport, "CurrentTransportState") ?: "STOPPED"
+        val volume = renderingControlURL?.let { runCatching { readVolume(it) }.getOrNull() }
+        return buildMap {
+            put("state", state)
+            put("position", hmsToSeconds(parseTag(position, "RelTime").orEmpty()))
+            put("duration", hmsToSeconds(parseTag(position, "TrackDuration").orEmpty()))
+            if (volume != null) put("volume", volume)
+        }
+    }
+
+    @Synchronized
+    fun getVolume(renderingControlURL: String): Int = readVolume(renderingControlURL)
+
+    @Synchronized
+    fun setVolume(renderingControlURL: String, volume: Int) {
+        val clamped = volume.coerceIn(0, 100)
+        soap(
+            renderingControlURL,
+            RC,
+            "SetVolume",
+            "<InstanceID>0</InstanceID><Channel>Master</Channel><DesiredVolume>$clamped</DesiredVolume>",
+        )
+    }
+
+    private fun readVolume(renderingControlURL: String): Int {
+        val xml = soap(
+            renderingControlURL,
+            RC,
+            "GetVolume",
+            "<InstanceID>0</InstanceID><Channel>Master</Channel>",
+        )
+        return parseTag(xml, "CurrentVolume")?.toIntOrNull()?.coerceIn(0, 100) ?: 0
+    }
+
+    private fun didl(url: String, title: String, mime: String): String {
+        return """
+            <DIDL-Lite xmlns="urn:schemas-upnp-org:metadata-1-0/DIDL-Lite/" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:upnp="urn:schemas-upnp-org:metadata-1-0/upnp/">
+              <item id="0" parentID="-1" restricted="1">
+                <dc:title>${escape(title)}</dc:title>
+                <upnp:class>object.item.audioItem.musicTrack</upnp:class>
+                <res protocolInfo="http-get:*:$mime:*">${escape(url)}</res>
+              </item>
+            </DIDL-Lite>
+        """.trimIndent()
+    }
+
+    private fun soap(url: String, ns: String, action: String, body: String): String {
+        val payload =
+            """<?xml version="1.0" encoding="utf-8"?>""" +
+                """<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/" s:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">""" +
+                """<s:Body><u:$action xmlns:u="$ns">$body</u:$action></s:Body></s:Envelope>"""
+        val conn = URL(url).openConnection() as HttpURLConnection
+        try {
+            conn.requestMethod = "POST"
+            conn.connectTimeout = 8000
+            conn.readTimeout = 8000
+            conn.doOutput = true
+            conn.setRequestProperty("Content-Type", "text/xml; charset=\"utf-8\"")
+            conn.setRequestProperty("SOAPAction", "\"$ns#$action\"")
+            conn.outputStream.use { it.write(payload.toByteArray(Charsets.UTF_8)) }
+            val stream = if (conn.responseCode in 200..299) conn.inputStream else conn.errorStream
+            val text = stream?.bufferedReader()?.use { it.readText() }.orEmpty()
+            if (conn.responseCode !in 200..299) {
+                throw IllegalStateException("UPnP $action failed: HTTP ${conn.responseCode} $text")
+            }
+            return text
+        } finally {
+            conn.disconnect()
+        }
+    }
+
+    private fun parseTag(xml: String, tag: String): String? {
+        return Regex("<(?:\\w+:)?$tag>([^<]*)</(?:\\w+:)?$tag>").find(xml)?.groupValues?.get(1)
+    }
+
+    private fun hmsToSeconds(hms: String): Double {
+        if (hms.isBlank() || hms.equals("NOT_IMPLEMENTED", ignoreCase = true)) return 0.0
+        val parts = hms.trim().split(":")
+        if (parts.size < 2) return 0.0
+        return try {
+            when (parts.size) {
+                2 -> parts[0].toDouble() * 60 + parts[1].toDouble()
+                else -> parts[0].toDouble() * 3600 + parts[1].toDouble() * 60 + parts[2].toDouble()
+            }
+        } catch (_: NumberFormatException) {
+            0.0
+        }
+    }
+
+    private fun secondsToHms(seconds: Double): String {
+        val total = seconds.toInt().coerceAtLeast(0)
+        val h = total / 3600
+        val m = (total % 3600) / 60
+        val s = total % 60
+        return "%02d:%02d:%02d".format(h, m, s)
+    }
+
+    private fun escape(value: String): String {
+        return value
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\"", "&quot;")
+            .replace("'", "&apos;")
+    }
+}

--- a/packages/dlna/expo-module.config.json
+++ b/packages/dlna/expo-module.config.json
@@ -1,0 +1,6 @@
+{
+	"platforms": ["android"],
+	"android": {
+		"modules": ["expo.modules.bbplayerdlna.BBPlayerDlnaModule"]
+	}
+}

--- a/packages/dlna/package.json
+++ b/packages/dlna/package.json
@@ -39,8 +39,8 @@
 		"react-native": "0.86.3"
 	},
 	"peerDependencies": {
-		"expo": "56.0.4",
+		"expo": ">=57.0.0",
 		"react": "19.2.3",
-		"react-native": "0.85.3"
+		"react-native": ">=0.86.0"
 	}
 }

--- a/packages/dlna/package.json
+++ b/packages/dlna/package.json
@@ -1,0 +1,46 @@
+{
+	"name": "@bbplayer/dlna",
+	"version": "0.1.0",
+	"description": "DLNA / UPnP MediaRenderer cast for BBPlayer",
+	"keywords": [
+		"bbplayer",
+		"dlna",
+		"expo",
+		"upnp"
+	],
+	"homepage": "https://github.com/bbplayer-app/bbplayer/tree/dev/packages/dlna",
+	"license": "MIT",
+	"author": "Roitium <65794453+roitium@users.noreply.github.com> (https://github.com/roitium)",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/bbplayer-app/bbplayer.git",
+		"directory": "packages/dlna"
+	},
+	"files": [
+		"src",
+		"android",
+		"expo-module.config.json"
+	],
+	"sideEffects": false,
+	"main": "src/index.ts",
+	"types": "src/index.ts",
+	"scripts": {
+		"build": "expo-module build",
+		"clean": "expo-module clean",
+		"expo-module": "expo-module",
+		"lint": "expo-module lint"
+	},
+	"devDependencies": {
+		"@types/jest": "^29.5.14",
+		"@types/react": "19.2.15",
+		"expo": "57.0.18",
+		"expo-module-scripts": "^56.0.2",
+		"react": "19.2.3",
+		"react-native": "0.86.3"
+	},
+	"peerDependencies": {
+		"expo": "56.0.4",
+		"react": "19.2.3",
+		"react-native": "0.85.3"
+	}
+}

--- a/packages/dlna/src/BBPlayerDlna.types.ts
+++ b/packages/dlna/src/BBPlayerDlna.types.ts
@@ -29,4 +29,5 @@ export interface DlnaPlaybackStatus {
 	state: string
 	position: number
 	duration: number
+	volume?: number
 }

--- a/packages/dlna/src/BBPlayerDlna.types.ts
+++ b/packages/dlna/src/BBPlayerDlna.types.ts
@@ -1,0 +1,32 @@
+export interface DlnaDevice {
+	name: string
+	location: string
+	controlURL: string
+	renderingControlURL?: string | null
+	udn?: string | null
+	manufacturer?: string | null
+	model?: string | null
+}
+
+export interface CastOptions {
+	controlURL: string
+	title: string
+	mime?: string
+	sourceUrl?: string
+	filePath?: string
+	headers?: Record<string, string>
+	headersJson?: string
+	renderingControlURL?: string
+}
+
+export interface CastSession {
+	listenUrl: string
+	controlURL: string
+	title: string
+}
+
+export interface DlnaPlaybackStatus {
+	state: string
+	position: number
+	duration: number
+}

--- a/packages/dlna/src/BBPlayerDlnaModule.ts
+++ b/packages/dlna/src/BBPlayerDlnaModule.ts
@@ -1,0 +1,57 @@
+import { NativeModule, requireNativeModule } from 'expo'
+import { Platform } from 'react-native'
+
+import type {
+	CastOptions,
+	CastSession,
+	DlnaDevice,
+	DlnaPlaybackStatus,
+} from './BBPlayerDlna.types'
+
+declare class BBPlayerDlnaNativeModule extends NativeModule {
+	discoverAsync(timeoutMs: number): Promise<DlnaDevice[]>
+	castAsync(options: CastOptions): Promise<CastSession>
+	stopCastAsync(): Promise<void>
+	getStatusAsync(): Promise<DlnaPlaybackStatus | null>
+	pauseCastAsync(): Promise<void>
+	resumeCastAsync(): Promise<void>
+	seekCastAsync(seconds: number): Promise<void>
+	isCasting(): boolean
+}
+
+let nativeModule: BBPlayerDlnaNativeModule | null = null
+
+const getNativeModule = () => {
+	if (Platform.OS !== 'android') {
+		throw new Error('DLNA 投屏目前只支持 Android')
+	}
+	nativeModule ??= requireNativeModule<BBPlayerDlnaNativeModule>('BBPlayerDlna')
+	return nativeModule
+}
+
+export const discoverDlnaDevices = (timeoutMs = 3000) =>
+	getNativeModule().discoverAsync(timeoutMs)
+
+export const castToDlna = (options: CastOptions) =>
+	getNativeModule().castAsync({
+		...options,
+		headersJson:
+			options.headersJson ??
+			(options.headers ? JSON.stringify(options.headers) : undefined),
+	})
+
+export const stopDlnaCast = () => getNativeModule().stopCastAsync()
+
+export const getDlnaStatus = () => getNativeModule().getStatusAsync()
+
+export const pauseDlnaCast = () => getNativeModule().pauseCastAsync()
+
+export const resumeDlnaCast = () => getNativeModule().resumeCastAsync()
+
+export const seekDlnaCast = (seconds: number) =>
+	getNativeModule().seekCastAsync(seconds)
+
+export const isDlnaCasting = () => {
+	if (Platform.OS !== 'android') return false
+	return getNativeModule().isCasting()
+}

--- a/packages/dlna/src/index.ts
+++ b/packages/dlna/src/index.ts
@@ -1,0 +1,16 @@
+export {
+	castToDlna,
+	discoverDlnaDevices,
+	getDlnaStatus,
+	isDlnaCasting,
+	pauseDlnaCast,
+	resumeDlnaCast,
+	seekDlnaCast,
+	stopDlnaCast,
+} from './BBPlayerDlnaModule'
+export type {
+	CastOptions,
+	CastSession,
+	DlnaDevice,
+	DlnaPlaybackStatus,
+} from './BBPlayerDlna.types'

--- a/packages/dlna/tsconfig.json
+++ b/packages/dlna/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "expo-module-scripts/tsconfig.base",
+	"compilerOptions": {
+		"skipLibCheck": true,
+		"exactOptionalPropertyTypes": false,
+		"outDir": "./build",
+		"rootDir": "./src"
+	},
+	"include": ["./src"],
+	"exclude": ["**/__mocks__/*", "**/__tests__/*", "**/__rsc_tests__/*"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
 
   apps/mobile:
     dependencies:
+      '@bbplayer/dlna':
+        specifier: workspace:*
+        version: link:../../packages/dlna
       '@bbplayer/heatmap':
         specifier: workspace:*
         version: link:../../packages/heatmap
@@ -685,6 +688,27 @@ importers:
         specifier: ~6.0.3
         version: 6.0.3
 
+  packages/dlna:
+    devDependencies:
+      '@types/jest':
+        specifier: ^29.5.14
+        version: 29.5.14
+      '@types/react':
+        specifier: 19.2.15
+        version: 19.2.15
+      expo:
+        specifier: 57.0.18
+        version: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
+      expo-module-scripts:
+        specifier: ^56.0.2
+        version: 56.0.2(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@30.2.0(supports-color@10.2.2))(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(esbuild@0.27.7)(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(expo@57.0.18)(jest-util@30.2.0)(jest@29.7.0(@types/node@25.2.3)(supports-color@10.2.2))(prettier@2.8.8)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
+      react:
+        specifier: 19.2.3
+        version: 19.2.3
+      react-native:
+        specifier: 0.86.3
+        version: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+
   packages/eslint-plugin: {}
 
   packages/expo-wavy-slider:
@@ -700,25 +724,25 @@ importers:
         version: 19.2.15
       expo:
         specifier: 57.0.18
-        version: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+        version: 57.0.18(c117059c9d8da59f92e2e60e68fa7f74)
       expo-module-scripts:
         specifier: ^56.0.2
-        version: 56.0.2(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@30.2.0(supports-color@10.2.2))(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(esbuild@0.27.7)(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(expo@57.0.18)(jest-util@30.2.0)(jest@29.7.0(@types/node@25.2.3)(supports-color@10.2.2))(prettier@2.8.8)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
+        version: 56.0.2(@babel/core@7.29.7(supports-color@10.2.2))(@jest/transform@30.2.0(supports-color@10.2.2))(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(esbuild@0.27.7)(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(expo@57.0.18)(jest-util@30.2.0)(jest@29.7.0(@types/node@25.2.3)(supports-color@10.2.2))(prettier@2.8.8)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
       expo-modules-core:
         specifier: 56.0.11
-        version: 56.0.11(d550c89ce303cbf8cb44e2ee7fad5837)
+        version: 56.0.11(ec041ae14a641bedf3450fa178b946f2)
       react:
         specifier: 19.2.3
         version: 19.2.3
       react-native:
         specifier: 0.86.3
-        version: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+        version: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
       react-native-reanimated:
         specifier: ~4.5.5
-        version: 4.5.5(d550c89ce303cbf8cb44e2ee7fad5837)
+        version: 4.5.5(ec041ae14a641bedf3450fa178b946f2)
       react-native-worklets:
         specifier: 0.11.4
-        version: 0.11.4(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
+        version: 0.11.4(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
       semantic-release:
         specifier: ^25.0.3
         version: 25.0.3(supports-color@10.2.2)(typescript@6.0.3)
@@ -1033,12 +1057,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-replace-supers@7.28.6':
-    resolution: {integrity: sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-
   '@babel/helper-replace-supers@7.29.7':
     resolution: {integrity: sha512-atfGXWSeCiF4DnKZIfmJfQRkSw9b9gNNXR1kqKjbhG4pGYCOnkp8OcTB8E3NXjBu8NpheSnOeNKz8KT7UNFTmQ==}
     engines: {node: '>=6.9.0'}
@@ -1222,12 +1240,6 @@ packages:
 
   '@babel/plugin-syntax-json-strings@7.8.3':
     resolution: {integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-syntax-jsx@7.28.6':
-    resolution: {integrity: sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==}
-    engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
@@ -1441,12 +1453,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-modules-commonjs@7.28.6':
-    resolution: {integrity: sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-modules-commonjs@7.29.7':
     resolution: {integrity: sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==}
     engines: {node: '>=6.9.0'}
@@ -1573,12 +1579,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
-  '@babel/plugin-transform-regenerator@7.28.6':
-    resolution: {integrity: sha512-eZhoEZHYQLL5uc1gS5e9/oTknS0sSSAtd5TkKMUp3J+S/CaUjagc0kOUPsEbDmMeva0nC3WWl4SxVY6+OBuxfw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
   '@babel/plugin-transform-regenerator@7.29.8':
     resolution: {integrity: sha512-0UpIXPtdDtMXfnV2OJAVMLpj3H/92vmkA6lpSRakmycJvj3VUy6Xs1dM8tXRugupykr5WB+LpiVl0J8LMVg2mg==}
     engines: {node: '>=6.9.0'}
@@ -1673,12 +1673,6 @@ packages:
     resolution: {integrity: sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==}
     peerDependencies:
       '@babel/core': ^7.0.0-0 || ^8.0.0-0 <8.0.0
-
-  '@babel/preset-typescript@7.27.1':
-    resolution: {integrity: sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
 
   '@babel/preset-typescript@7.29.7':
     resolution: {integrity: sha512-/Foi8vKY2EVbed/1eZx0gJEEwHAIxogrySI7rULcRIvhZzbvoE/b5qG5Ghc0WKAFKOHA9SD1x7RsFlOYdutIiQ==}
@@ -2567,19 +2561,6 @@ packages:
   '@expo-google-fonts/material-symbols@0.4.19':
     resolution: {integrity: sha512-hTcfTpjeXmkvngVnYAEN3eQDGQwQvQPFytXqgH+PO9JlUbY67iT8E5iJRTV0iIATem297vqy+1ZnA4VSeGurLg==}
 
-  '@expo/cli@57.0.20':
-    resolution: {integrity: sha512-ZjWz7SA5TBTyKq4+aFRUPgMFxmqHtKkDMv6d85J2UAAjdRhkNRf+B80t+rr5IFo2ywuTvyrPRBth4ei4w08olA==}
-    hasBin: true
-    peerDependencies:
-      expo: '*'
-      expo-router: '*'
-      react-native: '*'
-    peerDependenciesMeta:
-      expo-router:
-        optional: true
-      react-native:
-        optional: true
-
   '@expo/cli@57.0.22':
     resolution: {integrity: sha512-MdToR0ZZ1yjfkqbP1jcA7viS9duMPGq/C+qQ/21dtq+en583Ghp+O11BP/wujHa9ZGRtXimzuKPZDpPresVE0g==}
     hasBin: true
@@ -2727,28 +2708,6 @@ packages:
       typescript:
         optional: true
 
-  '@expo/router-server@57.0.8':
-    resolution: {integrity: sha512-lEPGYoDmh97yyEcY/MFWQsfE7yIgMRnGDcnsBN7B6AiWBFSJIMEcGnO0aYPgY0ZjNWyJDi7Ee8QZRGqB+LhI6w==}
-    peerDependencies:
-      '@expo/metro-runtime': ^57.0.14
-      expo: '*'
-      expo-constants: ^57.0.15
-      expo-font: ^57.0.1
-      expo-router: '*'
-      expo-server: ^57.0.3
-      react: '*'
-      react-dom: '*'
-      react-server-dom-webpack: ~19.0.1 || ~19.1.2 || ~19.2.1
-    peerDependenciesMeta:
-      '@expo/metro-runtime':
-        optional: true
-      expo-router:
-        optional: true
-      react-dom:
-        optional: true
-      react-server-dom-webpack:
-        optional: true
-
   '@expo/router-server@57.0.9':
     resolution: {integrity: sha512-/PxRQozFesIyCJZOAtrQE8XcmcojNiL5ctPMQnbE4ojC2EJPu0zc7c0Y4PuXsoRxrZxm8Usw76/lCVrXcfTZ2w==}
     peerDependencies:
@@ -2779,10 +2738,6 @@ packages:
 
   '@expo/server@0.5.3':
     resolution: {integrity: sha512-WXsWzeBs5v/h0PUfHyNLLz07rwwO5myQ1A5DGYewyyGLmsyl61yVCe8AgAlp1wkiMsqhj2hZqI2u3K10QnCMrQ==}
-
-  '@expo/spawn-async@1.7.2':
-    resolution: {integrity: sha512-QdWi16+CHB9JYP7gma19OVVg0BFkvU8zNj9GjWorYI8Iv8FUxjOCcYRuAmX4s/h91e4e7BPsskc8cSrZYho9Ew==}
-    engines: {node: '>=12'}
 
   '@expo/spawn-async@1.8.0':
     resolution: {integrity: sha512-eb9xxd/LbuEGSdua4NumCu/McVB9EM+F/JxB9pWgnERw4HQ9XyTNH1KapG6oqLWR8TuRK2LQfzJlmNi94CVobw==}
@@ -6222,11 +6177,6 @@ packages:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
     engines: {node: '>= 20'}
 
-  agent-cli-detector@0.1.6:
-    resolution: {integrity: sha512-vKrPeEVN3upDF3GjWxsWBbwQgMtNJ8VB1cduPvK3svmmz4ENpS7yaPxbogsbe3w+xp9xp2Cu+0Ar41rjAR4+lA==}
-    engines: {node: '>=18.18'}
-    hasBin: true
-
   agent-cli-detector@0.1.7:
     resolution: {integrity: sha512-d8OWDVdZMgjhLUT9ZPgSv/BdFFF9pVuscC0JdUSz3bjwE15gcp6u/o0/JooM2yyAWC49KThFhXlgTXRa9B7yng==}
     engines: {node: '>=18.18'}
@@ -6488,11 +6438,6 @@ packages:
   babel-plugin-module-resolver@5.0.2:
     resolution: {integrity: sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==}
 
-  babel-plugin-polyfill-corejs2@0.4.14:
-    resolution: {integrity: sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-
   babel-plugin-polyfill-corejs2@0.4.17:
     resolution: {integrity: sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==}
     peerDependencies:
@@ -6500,11 +6445,6 @@ packages:
 
   babel-plugin-polyfill-corejs3@0.13.0:
     resolution: {integrity: sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==}
-    peerDependencies:
-      '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
-
-  babel-plugin-polyfill-regenerator@0.6.5:
-    resolution: {integrity: sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==}
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
@@ -6560,21 +6500,6 @@ packages:
       '@babel/runtime': ^7.20.0
       expo: '*'
       expo-widgets: ^57.0.16
-      react-refresh: '>=0.14.0 <1.0.0'
-    peerDependenciesMeta:
-      '@babel/runtime':
-        optional: true
-      expo:
-        optional: true
-      expo-widgets:
-        optional: true
-
-  babel-preset-expo@57.0.9:
-    resolution: {integrity: sha512-T19biGOBTnMp161PyBqWOoSIEeZug8/EjtuUdVob8JPQKZMTalHUQaQt+qtQQE7XsEkZJ6erb3k0CohneTFzQg==}
-    peerDependencies:
-      '@babel/runtime': ^7.20.0
-      expo: '*'
-      expo-widgets: ^57.0.13
       react-refresh: '>=0.14.0 <1.0.0'
     peerDependenciesMeta:
       '@babel/runtime':
@@ -7632,10 +7557,6 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
-  enhanced-resolve@5.18.4:
-    resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
-    engines: {node: '>=10.13.0'}
-
   enhanced-resolve@5.24.5:
     resolution: {integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==}
     engines: {node: '>=10.13.0'}
@@ -8198,16 +8119,6 @@ packages:
       react-native-worklets:
         optional: true
 
-  expo-modules-core@57.0.14:
-    resolution: {integrity: sha512-Cg3aQnVsQhZcMOF/RFgPGzMuhIak5W9eR9ecwmFSeQ813r4/49ut6RMA6PqUuUKuPCUIRqnBAHfSyTm1W9nfzg==}
-    peerDependencies:
-      react: '*'
-      react-native: '*'
-      react-native-worklets: ^0.7.4 || ^0.8.0 || ^0.9.0 || ^0.10.0
-    peerDependenciesMeta:
-      react-native-worklets:
-        optional: true
-
   expo-modules-core@57.0.16:
     resolution: {integrity: sha512-vPbxDOdvG6Ucpws5ucdbQa+nNmdxKONS1fTg92sy0p4TnHX8hBiExtbrtUA/5+1t3FRCUuiy29/1nJEGdt3E4A==}
     peerDependencies:
@@ -8220,11 +8131,6 @@ packages:
 
   expo-modules-jsi@56.0.7:
     resolution: {integrity: sha512-iBAj4Xeh/8HT201VVxFlmf+VBfmtQV1ZUoJdLQQENm0+j9gnD2QswZLJyNo3CmNNXl46esJeLR5lpGpYZts/zA==}
-    peerDependencies:
-      react-native: '*'
-
-  expo-modules-jsi@57.0.6:
-    resolution: {integrity: sha512-WK0xFEe0FdZTCLCdfXK+HVNYfAmEbA6goecRxqjr0gh3XYRKAr9tikxqcM0ItLQoEPKntscPZhWcPLGvr97Tfw==}
     peerDependencies:
       react-native: '*'
 
@@ -8789,10 +8695,6 @@ packages:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
-
-  glob@13.0.0:
-    resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
-    engines: {node: 20 || >=22}
 
   glob@13.0.6:
     resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
@@ -10388,10 +10290,6 @@ packages:
     resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
     engines: {node: '>=8'}
 
-  minipass@7.1.2:
-    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -10938,10 +10836,6 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
-
-  path-scurry@2.0.1:
-    resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
-    engines: {node: 20 || >=22}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -12446,10 +12340,6 @@ packages:
   tailwindcss@4.3.3:
     resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
 
-  tapable@2.3.0:
-    resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
-    engines: {node: '>=6'}
-
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
@@ -13658,15 +13548,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-optimise-call-expression': 7.29.7
-      '@babel/traverse': 7.29.8(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.0(supports-color@10.2.2)
@@ -13927,11 +13808,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.29.7
-
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
@@ -14296,14 +14172,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-modules-commonjs@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
       '@babel/core': 7.29.0(supports-color@10.2.2)
@@ -14325,7 +14193,7 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
@@ -14396,7 +14264,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -14553,11 +14421,6 @@ snapshots:
       '@babel/helper-annotate-as-pure': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-transform-regenerator@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.29.7
-
   '@babel/plugin-transform-regenerator@7.29.8(@babel/core@7.29.0(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.0(supports-color@10.2.2)
@@ -14694,9 +14557,9 @@ snapshots:
 
   '@babel/preset-env@7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
-      '@babel/compat-data': 7.28.6
+      '@babel/compat-data': 7.29.7
       '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-compilation-targets': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-validator-option': 7.29.7
       '@babel/plugin-bugfix-firefox-class-in-computed-class-key': 7.28.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
@@ -14747,7 +14610,7 @@ snapshots:
       '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       '@babel/plugin-transform-property-literals': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-regenerator': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-regenerator': 7.29.8(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/plugin-transform-regexp-modifiers': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/plugin-transform-reserved-words': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
@@ -14760,9 +14623,9 @@ snapshots:
       '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/plugin-transform-unicode-sets-regex': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/preset-modules': 0.1.6-no-external-plugins(@babel/core@7.29.7(supports-color@10.2.2))
-      babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       core-js-compat: 3.45.1
       semver: 6.3.1
     transitivePeerDependencies:
@@ -14774,17 +14637,6 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/types': 7.29.8
       esutils: 2.0.3
-
-  '@babel/preset-typescript@7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-plugin-utils': 7.29.7
-      '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-modules-commonjs': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/preset-typescript@7.29.7(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2)':
     dependencies:
@@ -15501,162 +15353,6 @@ snapshots:
 
   '@expo-google-fonts/material-symbols@0.4.19': {}
 
-  '@expo/cli@57.0.20(8e12489a441466148eeae54ed24d0d3d)':
-    dependencies:
-      '@expo/code-signing-certificates': 0.0.6
-      '@expo/config': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/config-plugins': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/devcert': 1.2.1(supports-color@10.2.2)
-      '@expo/env': 2.4.3(supports-color@10.2.2)
-      '@expo/image-utils': 0.11.5(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/inline-modules': 0.1.7(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/json-file': 11.0.1
-      '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      '@expo/metro': 56.0.2(supports-color@10.2.2)
-      '@expo/metro-config': 57.0.12(expo@57.0.18)(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/metro-file-map': 57.0.2(supports-color@10.2.2)
-      '@expo/osascript': 2.7.1
-      '@expo/package-manager': 1.13.1
-      '@expo/plist': 0.8.1
-      '@expo/prebuild-config': 57.0.15(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/require-utils': 57.0.5(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/router-server': 57.0.8(b7202930e5bbd763e8f07a2c5bb21a05)
-      '@expo/schema-utils': 57.0.2
-      '@expo/spawn-async': 1.8.0
-      '@expo/ws-tunnel': 2.0.0(ws@8.21.0)
-      '@expo/xcpretty': 4.4.4
-      '@react-native/dev-middleware': 0.86.3(supports-color@10.2.2)
-      accepts: 1.3.8
-      agent-cli-detector: 0.1.6
-      arg: 5.0.2
-      bplist-creator: 0.1.0
-      bplist-parser: 0.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      compression: 1.8.1(supports-color@10.2.2)
-      connect: 3.7.0(supports-color@10.2.2)
-      debug: 4.4.3(supports-color@10.2.2)
-      dnssd-advertise: 1.1.6
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
-      expo-server: 57.0.3
-      fetch-nodeshim: 0.4.10
-      getenv: 2.0.0
-      glob: 13.0.6
-      lan-network: 0.2.1
-      multitars: 1.0.2
-      node-forge: 1.4.0
-      npm-package-arg: 11.0.3
-      ora: 3.4.0
-      picomatch: 4.0.4
-      pretty-format: 29.7.0
-      progress: 2.0.3
-      prompts: 2.4.2
-      resolve-from: 5.0.0
-      sandbox-cli-detector: 0.2.0
-      semver: 7.8.5
-      send: 0.19.2(supports-color@10.2.2)
-      slugify: 1.6.6
-      stacktrace-parser: 0.1.11
-      structured-headers: 0.4.1
-      terminal-link: 2.1.1
-      toqr: 0.1.1
-      wrap-ansi: 7.0.0
-      ws: 8.21.0
-      zod: 3.25.76
-    optionalDependencies:
-      expo-router: 57.0.19(d0ac48ab5e3ef0a158fc3a7914224102)
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - '@expo/dom-webview'
-      - '@expo/metro-runtime'
-      - bufferutil
-      - expo-constants
-      - expo-font
-      - react
-      - react-dom
-      - react-server-dom-webpack
-      - supports-color
-      - typescript
-      - utf-8-validate
-
-  '@expo/cli@57.0.20(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)':
-    dependencies:
-      '@expo/code-signing-certificates': 0.0.6
-      '@expo/config': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/config-plugins': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/devcert': 1.2.1(supports-color@10.2.2)
-      '@expo/env': 2.4.3(supports-color@10.2.2)
-      '@expo/image-utils': 0.11.5(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/inline-modules': 0.1.7(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/json-file': 11.0.1
-      '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      '@expo/metro': 56.0.2(supports-color@10.2.2)
-      '@expo/metro-config': 57.0.12(expo@57.0.18)(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/metro-file-map': 57.0.2(supports-color@10.2.2)
-      '@expo/osascript': 2.7.1
-      '@expo/package-manager': 1.13.1
-      '@expo/plist': 0.8.1
-      '@expo/prebuild-config': 57.0.15(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/require-utils': 57.0.5(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/router-server': 57.0.8(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo-server@57.0.3)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@10.2.2)
-      '@expo/schema-utils': 57.0.2
-      '@expo/spawn-async': 1.8.0
-      '@expo/ws-tunnel': 2.0.0(ws@8.21.0)
-      '@expo/xcpretty': 4.4.4
-      '@react-native/dev-middleware': 0.86.3(supports-color@10.2.2)
-      accepts: 1.3.8
-      agent-cli-detector: 0.1.6
-      arg: 5.0.2
-      bplist-creator: 0.1.0
-      bplist-parser: 0.3.2
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      compression: 1.8.1(supports-color@10.2.2)
-      connect: 3.7.0(supports-color@10.2.2)
-      debug: 4.4.3(supports-color@10.2.2)
-      dnssd-advertise: 1.1.6
-      expo: 57.0.18(c117059c9d8da59f92e2e60e68fa7f74)
-      expo-server: 57.0.3
-      fetch-nodeshim: 0.4.10
-      getenv: 2.0.0
-      glob: 13.0.6
-      lan-network: 0.2.1
-      multitars: 1.0.2
-      node-forge: 1.4.0
-      npm-package-arg: 11.0.3
-      ora: 3.4.0
-      picomatch: 4.0.4
-      pretty-format: 29.7.0
-      progress: 2.0.3
-      prompts: 2.4.2
-      resolve-from: 5.0.0
-      sandbox-cli-detector: 0.2.0
-      semver: 7.8.5
-      send: 0.19.2(supports-color@10.2.2)
-      slugify: 1.6.6
-      stacktrace-parser: 0.1.11
-      structured-headers: 0.4.1
-      terminal-link: 2.1.1
-      toqr: 0.1.1
-      wrap-ansi: 7.0.0
-      ws: 8.21.0
-      zod: 3.25.76
-    optionalDependencies:
-      expo-router: 57.0.19(6fbf87c593f7e175b5adc91463d41515)
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - '@expo/dom-webview'
-      - '@expo/metro-runtime'
-      - bufferutil
-      - expo-constants
-      - expo-font
-      - react
-      - react-dom
-      - react-server-dom-webpack
-      - supports-color
-      - typescript
-      - utf-8-validate
-
   '@expo/cli@57.0.22(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.17)(expo@57.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
@@ -15721,6 +15417,162 @@ snapshots:
       zod: 3.25.76
     optionalDependencies:
       expo-router: 57.0.17(4bdc88406a815accd71fdd18977200ab)
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - '@expo/dom-webview'
+      - '@expo/metro-runtime'
+      - bufferutil
+      - expo-constants
+      - expo-font
+      - react
+      - react-dom
+      - react-server-dom-webpack
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@expo/cli@57.0.22(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)':
+    dependencies:
+      '@expo/code-signing-certificates': 0.0.6
+      '@expo/config': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/config-plugins': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/devcert': 1.2.1(supports-color@10.2.2)
+      '@expo/env': 2.4.3(supports-color@10.2.2)
+      '@expo/image-utils': 0.11.5(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/inline-modules': 0.1.7(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/json-file': 11.0.1
+      '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      '@expo/metro': 56.0.2(supports-color@10.2.2)
+      '@expo/metro-config': 57.0.12(expo@57.0.18)(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/metro-file-map': 57.0.2(supports-color@10.2.2)
+      '@expo/osascript': 2.7.1
+      '@expo/package-manager': 1.13.1
+      '@expo/plist': 0.8.1
+      '@expo/prebuild-config': 57.0.15(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/require-utils': 57.0.5(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/router-server': 57.0.9(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo-server@57.0.3)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@10.2.2)
+      '@expo/schema-utils': 57.0.2
+      '@expo/spawn-async': 1.8.0
+      '@expo/ws-tunnel': 2.0.0(ws@8.21.0)
+      '@expo/xcpretty': 4.4.4
+      '@react-native/dev-middleware': 0.86.3(supports-color@10.2.2)
+      accepts: 1.3.8
+      agent-cli-detector: 0.1.7
+      arg: 5.0.2
+      bplist-creator: 0.1.0
+      bplist-parser: 0.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      compression: 1.8.1(supports-color@10.2.2)
+      connect: 3.7.0(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.2.2)
+      dnssd-advertise: 1.1.6
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
+      expo-server: 57.0.3
+      fetch-nodeshim: 0.4.10
+      getenv: 2.0.0
+      glob: 13.0.6
+      lan-network: 0.2.1
+      multitars: 1.0.2
+      node-forge: 1.4.0
+      npm-package-arg: 11.0.3
+      ora: 3.4.0
+      picomatch: 4.0.4
+      pretty-format: 29.7.0
+      progress: 2.0.3
+      prompts: 2.4.2
+      resolve-from: 5.0.0
+      sandbox-cli-detector: 0.2.0
+      semver: 7.8.5
+      send: 0.19.2(supports-color@10.2.2)
+      slugify: 1.6.6
+      stacktrace-parser: 0.1.11
+      structured-headers: 0.4.1
+      terminal-link: 2.1.1
+      toqr: 0.1.1
+      wrap-ansi: 7.0.0
+      ws: 8.21.0
+      zod: 3.25.76
+    optionalDependencies:
+      expo-router: 57.0.19(64e24ee6d2d1f55d48af07a1c8d113d1)
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - '@expo/dom-webview'
+      - '@expo/metro-runtime'
+      - bufferutil
+      - expo-constants
+      - expo-font
+      - react
+      - react-dom
+      - react-server-dom-webpack
+      - supports-color
+      - typescript
+      - utf-8-validate
+
+  '@expo/cli@57.0.22(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)':
+    dependencies:
+      '@expo/code-signing-certificates': 0.0.6
+      '@expo/config': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/config-plugins': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/devcert': 1.2.1(supports-color@10.2.2)
+      '@expo/env': 2.4.3(supports-color@10.2.2)
+      '@expo/image-utils': 0.11.5(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/inline-modules': 0.1.7(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/json-file': 11.0.1
+      '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      '@expo/metro': 56.0.2(supports-color@10.2.2)
+      '@expo/metro-config': 57.0.12(expo@57.0.18)(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/metro-file-map': 57.0.2(supports-color@10.2.2)
+      '@expo/osascript': 2.7.1
+      '@expo/package-manager': 1.13.1
+      '@expo/plist': 0.8.1
+      '@expo/prebuild-config': 57.0.15(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/require-utils': 57.0.5(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/router-server': 57.0.9(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo-server@57.0.3)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@10.2.2)
+      '@expo/schema-utils': 57.0.2
+      '@expo/spawn-async': 1.8.0
+      '@expo/ws-tunnel': 2.0.0(ws@8.21.0)
+      '@expo/xcpretty': 4.4.4
+      '@react-native/dev-middleware': 0.86.3(supports-color@10.2.2)
+      accepts: 1.3.8
+      agent-cli-detector: 0.1.7
+      arg: 5.0.2
+      bplist-creator: 0.1.0
+      bplist-parser: 0.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      compression: 1.8.1(supports-color@10.2.2)
+      connect: 3.7.0(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@10.2.2)
+      dnssd-advertise: 1.1.6
+      expo: 57.0.18(c117059c9d8da59f92e2e60e68fa7f74)
+      expo-server: 57.0.3
+      fetch-nodeshim: 0.4.10
+      getenv: 2.0.0
+      glob: 13.0.6
+      lan-network: 0.2.1
+      multitars: 1.0.2
+      node-forge: 1.4.0
+      npm-package-arg: 11.0.3
+      ora: 3.4.0
+      picomatch: 4.0.4
+      pretty-format: 29.7.0
+      progress: 2.0.3
+      prompts: 2.4.2
+      resolve-from: 5.0.0
+      sandbox-cli-detector: 0.2.0
+      semver: 7.8.5
+      send: 0.19.2(supports-color@10.2.2)
+      slugify: 1.6.6
+      stacktrace-parser: 0.1.11
+      structured-headers: 0.4.1
+      terminal-link: 2.1.1
+      toqr: 0.1.1
+      wrap-ansi: 7.0.0
+      ws: 8.21.0
+      zod: 3.25.76
+    optionalDependencies:
+      expo-router: 57.0.19(6da7b9cb5221a62efdf8a9f744f5df86)
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -15813,7 +15665,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@expo/cli@57.0.22(d6b936a442563129ff9ca7125129d3f5)':
+  '@expo/cli@57.0.22(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo@57.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)':
     dependencies:
       '@expo/code-signing-certificates': 0.0.6
       '@expo/config': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
@@ -15832,7 +15684,7 @@ snapshots:
       '@expo/plist': 0.8.1
       '@expo/prebuild-config': 57.0.15(supports-color@10.2.2)(typescript@6.0.3)
       '@expo/require-utils': 57.0.5(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/router-server': 57.0.9(5ab48e14dabf80445d7658a311187618)
+      '@expo/router-server': 57.0.9(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo-server@57.0.3)(expo@57.0.20)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@10.2.2)
       '@expo/schema-utils': 57.0.2
       '@expo/spawn-async': 1.8.0
       '@expo/ws-tunnel': 2.0.0(ws@8.21.0)
@@ -15876,7 +15728,7 @@ snapshots:
       ws: 8.21.0
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 57.0.19(96a421b3dfa305f0d6d2398defeb4a2c)
+      expo-router: 57.0.19(9a3e256f20652013fddcff365c2f476d)
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
     transitivePeerDependencies:
       - '@expo/dom-webview'
@@ -15984,7 +15836,7 @@ snapshots:
 
   '@expo/dom-webview@57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)':
     dependencies:
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
 
@@ -16093,7 +15945,7 @@ snapshots:
     dependencies:
       '@expo/dom-webview': 57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       anser: 1.4.10
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
       stacktrace-parser: 0.1.11
@@ -16153,7 +16005,7 @@ snapshots:
       postcss: 8.5.15
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16186,7 +16038,7 @@ snapshots:
       postcss: 8.5.15
       resolve-from: 5.0.0
     optionalDependencies:
-      expo: 57.0.20(87a0a49f1bf035cc15b0a7018dcdb3f6)
+      expo: 57.0.20(7ee86f2dba25c3be925d72094eb565e5)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -16208,7 +16060,7 @@ snapshots:
     dependencies:
       '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       anser: 1.4.10
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
       pretty-format: 29.7.0
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
@@ -16330,51 +16182,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@expo/router-server@57.0.8(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo-server@57.0.3)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@10.2.2)':
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      expo: 57.0.18(c117059c9d8da59f92e2e60e68fa7f74)
-      expo-constants: 57.0.17(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(supports-color@10.2.2)
-      expo-font: 57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      expo-server: 57.0.3
-      react: 19.2.3
-    optionalDependencies:
-      '@expo/metro-runtime': 57.0.15(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      expo-router: 57.0.19(6fbf87c593f7e175b5adc91463d41515)
-      react-dom: 19.2.3(react@19.2.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@expo/router-server@57.0.8(b7202930e5bbd763e8f07a2c5bb21a05)':
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
-      expo-constants: 57.0.17(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(supports-color@10.2.2)
-      expo-font: 57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      expo-server: 57.0.3
-      react: 19.2.3
-    optionalDependencies:
-      '@expo/metro-runtime': 57.0.15(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      expo-router: 57.0.19(d0ac48ab5e3ef0a158fc3a7914224102)
-      react-dom: 19.2.3(react@19.2.3)
-    transitivePeerDependencies:
-      - supports-color
-
-  '@expo/router-server@57.0.9(5ab48e14dabf80445d7658a311187618)':
-    dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
-      expo: 57.0.20(87a0a49f1bf035cc15b0a7018dcdb3f6)
-      expo-constants: 57.0.17(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(supports-color@10.2.2)
-      expo-font: 57.0.3(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      expo-server: 57.0.3
-      react: 19.2.3
-    optionalDependencies:
-      '@expo/metro-runtime': 57.0.15(@expo/log-box@57.0.4)(expo@57.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      expo-router: 57.0.19(96a421b3dfa305f0d6d2398defeb4a2c)
-      react-dom: 19.2.3(react@19.2.3)
-    transitivePeerDependencies:
-      - supports-color
-
   '@expo/router-server@57.0.9(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.17)(expo-server@57.0.3)(expo@57.0.20)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@10.2.2)':
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -16386,6 +16193,21 @@ snapshots:
     optionalDependencies:
       '@expo/metro-runtime': 57.0.15(@expo/log-box@57.0.4)(expo@57.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       expo-router: 57.0.17(4bdc88406a815accd71fdd18977200ab)
+      react-dom: 19.2.3(react@19.2.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/router-server@57.0.9(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo-server@57.0.3)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(supports-color@10.2.2)':
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
+      expo-constants: 57.0.17(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(supports-color@10.2.2)
+      expo-font: 57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      expo-server: 57.0.3
+      react: 19.2.3
+    optionalDependencies:
+      '@expo/metro-runtime': 57.0.15(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      expo-router: 57.0.19(64e24ee6d2d1f55d48af07a1c8d113d1)
       react-dom: 19.2.3(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -16417,10 +16239,6 @@ snapshots:
       undici: 6.25.0
     transitivePeerDependencies:
       - supports-color
-
-  '@expo/spawn-async@1.7.2':
-    dependencies:
-      cross-spawn: 7.0.6
 
   '@expo/spawn-async@1.8.0':
     dependencies:
@@ -16474,6 +16292,22 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
+  '@expo/ui@57.0.16(0609eed03e06ad4c6d880f425abe60fb)':
+    dependencies:
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
+      react: 19.2.3
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+      sf-symbols-typescript: 2.2.0
+      vaul: 1.1.2(@types/react-dom@19.2.5(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    optionalDependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      react-dom: 19.2.3(react@19.2.3)
+      react-native-worklets: 0.10.1(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+    optional: true
+
   '@expo/ui@57.0.16(63b5e6c70a6db2d07a8b4824f115dcf6)':
     dependencies:
       expo: 57.0.20(87a0a49f1bf035cc15b0a7018dcdb3f6)
@@ -16485,22 +16319,6 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       react-dom: 19.2.3(react@19.2.3)
       react-native-worklets: 0.10.1(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
-    transitivePeerDependencies:
-      - '@types/react'
-      - '@types/react-dom'
-    optional: true
-
-  '@expo/ui@57.0.16(b7aea1f940e916a89a77cd4011839798)':
-    dependencies:
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
-      react: 19.2.3
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-      sf-symbols-typescript: 2.2.0
-      vaul: 1.1.2(@types/react-dom@19.2.5(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-    optionalDependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      react-dom: 19.2.3(react@19.2.3)
-      react-native-worklets: 0.11.4(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -20420,8 +20238,6 @@ snapshots:
 
   agent-base@9.0.0: {}
 
-  agent-cli-detector@0.1.6: {}
-
   agent-cli-detector@0.1.7: {}
 
   aggregate-error@3.1.0:
@@ -20788,15 +20604,6 @@ snapshots:
       reselect: 4.1.8
       resolve: 1.22.11
 
-  babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2):
-    dependencies:
-      '@babel/compat-data': 7.28.6
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      semver: 6.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
       '@babel/compat-data': 7.29.7
@@ -20828,13 +20635,6 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
       core-js-compat: 3.45.1
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-polyfill-regenerator@0.6.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2):
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -21026,6 +20826,58 @@ snapshots:
       - '@babel/core'
       - supports-color
 
+  babel-preset-expo@57.0.10(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(expo@57.0.18)(react-refresh@0.14.2)(supports-color@10.2.2):
+    dependencies:
+      '@babel/generator': 7.29.8
+      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
+      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@react-native/babel-plugin-codegen': 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      babel-plugin-react-compiler: 1.0.0
+      babel-plugin-react-native-web: 0.21.1
+      babel-plugin-syntax-hermes-parser: 0.36.1
+      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7(supports-color@10.2.2))
+      debug: 4.4.3(supports-color@10.2.2)
+      react-refresh: 0.14.2
+    optionalDependencies:
+      '@babel/runtime': 7.29.7
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - supports-color
+
   babel-preset-expo@57.0.10(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(expo@57.0.20)(react-refresh@0.14.2)(supports-color@10.2.2):
     dependencies:
       '@babel/generator': 7.29.8
@@ -21074,58 +20926,6 @@ snapshots:
     optionalDependencies:
       '@babel/runtime': 7.29.7
       expo: 57.0.20(87a0a49f1bf035cc15b0a7018dcdb3f6)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - supports-color
-
-  babel-preset-expo@57.0.9(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(expo@57.0.18)(react-refresh@0.14.2)(supports-color@10.2.2):
-    dependencies:
-      '@babel/generator': 7.29.8
-      '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
-      '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-proposal-export-default-from': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-export-default-from': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-async-generator-functions': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-async-to-generator': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-block-scoping': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-class-static-block': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-destructuring': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-flow-strip-types': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-for-of': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-logical-assignment-operators': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-modules-commonjs': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-object-rest-spread': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-optional-catch-binding': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-parameters': 7.27.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-private-methods': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-private-property-in-object': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-react-display-name': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-react-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-runtime': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@react-native/babel-plugin-codegen': 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      babel-plugin-react-compiler: 1.0.0
-      babel-plugin-react-native-web: 0.21.1
-      babel-plugin-syntax-hermes-parser: 0.36.1
-      babel-plugin-transform-flow-enums: 0.0.2(@babel/core@7.29.7(supports-color@10.2.2))
-      debug: 4.4.3(supports-color@10.2.2)
-      react-refresh: 0.14.2
-    optionalDependencies:
-      '@babel/runtime': 7.29.7
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
     transitivePeerDependencies:
       - '@babel/core'
       - supports-color
@@ -22102,11 +21902,6 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.18.4:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.0
-
   enhanced-resolve@5.24.5:
     dependencies:
       graceful-fs: 4.2.11
@@ -22490,7 +22285,7 @@ snapshots:
   eslint-plugin-n@17.23.2(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(typescript@6.0.3):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))
-      enhanced-resolve: 5.18.4
+      enhanced-resolve: 5.24.5
       eslint: 9.39.4(jiti@2.7.0)(supports-color@10.2.2)
       eslint-plugin-es-x: 7.8.0(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))
       get-tsconfig: 4.10.1
@@ -22509,7 +22304,7 @@ snapshots:
       eslint-utils: 2.1.0
       ignore: 5.3.2
       minimatch: 3.1.5
-      resolve: 1.22.11
+      resolve: 1.22.12
       semver: 6.3.1
 
   eslint-plugin-prettier@5.5.5(eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2)))(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(prettier@2.8.8):
@@ -22773,7 +22568,7 @@ snapshots:
   expo-asset@57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3):
     dependencies:
       '@expo/image-utils': 0.11.5(supports-color@10.2.2)(typescript@6.0.3)
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
       expo-constants: 57.0.17(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(supports-color@10.2.2)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
@@ -22848,7 +22643,7 @@ snapshots:
   expo-constants@57.0.17(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(supports-color@10.2.2):
     dependencies:
       '@expo/env': 2.4.3(supports-color@10.2.2)
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
     transitivePeerDependencies:
       - supports-color
@@ -22914,7 +22709,7 @@ snapshots:
 
   expo-file-system@57.0.6(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)):
     dependencies:
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
 
   expo-file-system@57.0.6(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)):
@@ -22934,7 +22729,7 @@ snapshots:
 
   expo-font@57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3):
     dependencies:
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
       fontfaceobserver: 2.3.0
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
@@ -22962,7 +22757,7 @@ snapshots:
 
   expo-glass-effect@57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3):
     dependencies:
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
     optional: true
@@ -23008,12 +22803,12 @@ snapshots:
 
   expo-keep-awake@57.0.1(expo@57.0.18)(react@19.2.3):
     dependencies:
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
       react: 19.2.3
 
   expo-keep-awake@57.0.1(expo@57.0.20)(react@19.2.3):
     dependencies:
-      expo: 57.0.20(87a0a49f1bf035cc15b0a7018dcdb3f6)
+      expo: 57.0.20(7ee86f2dba25c3be925d72094eb565e5)
       react: 19.2.3
 
   expo-linear-gradient@57.0.1(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3):
@@ -23079,15 +22874,15 @@ snapshots:
       '@babel/cli': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/preset-env': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/preset-typescript': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@expo/spawn-async': 1.7.2
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@expo/spawn-async': 1.8.0
       '@react-native/jest-preset': 0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
       '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@25.2.3)(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/jest': 29.5.14
       babel-plugin-dynamic-import-node: 2.3.3
       commander: 12.1.0
       eslint-config-universe: 15.1.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(prettier@2.8.8)(supports-color@10.2.2)(typescript@6.0.3)
-      glob: 13.0.0
+      glob: 13.0.6
       jest-expo: 56.0.5(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(expo@57.0.18)(jest@29.7.0(@types/node@25.2.3)(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
       jest-snapshot-prettier: prettier@2.8.8
       jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@25.2.3)(supports-color@10.2.2))
@@ -23122,15 +22917,15 @@ snapshots:
       '@babel/cli': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/plugin-transform-export-namespace-from': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
       '@babel/preset-env': 7.28.6(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/preset-typescript': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@expo/spawn-async': 1.7.2
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@expo/spawn-async': 1.8.0
       '@react-native/jest-preset': 0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
       '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@25.2.3)(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/jest': 29.5.14
       babel-plugin-dynamic-import-node: 2.3.3
       commander: 12.1.0
       eslint-config-universe: 15.1.1(eslint@9.39.4(jiti@2.7.0)(supports-color@10.2.2))(prettier@2.8.8)(supports-color@10.2.2)(typescript@6.0.3)
-      glob: 13.0.0
+      glob: 13.0.6
       jest-expo: 56.0.5(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(expo@57.0.18)(jest@29.7.0(@types/node@25.2.3)(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
       jest-snapshot-prettier: prettier@2.8.8
       jest-watch-typeahead: 2.2.1(jest@29.7.0(@types/node@25.2.3)(supports-color@10.2.2))
@@ -23170,40 +22965,10 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-modules-core@56.0.11(d550c89ce303cbf8cb44e2ee7fad5837):
+  expo-modules-core@56.0.11(ec041ae14a641bedf3450fa178b946f2):
     dependencies:
       '@expo/expo-modules-macros-plugin': 0.0.9
-      expo-modules-jsi: 56.0.7(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))
-      invariant: 2.2.4
-      react: 19.2.3
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-    optionalDependencies:
-      react-native-worklets: 0.11.4(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
-
-  expo-modules-core@57.0.14(d550c89ce303cbf8cb44e2ee7fad5837):
-    dependencies:
-      '@expo/expo-modules-macros-plugin': 0.6.1
-      expo-modules-jsi: 57.0.6(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))
-      invariant: 2.2.4
-      react: 19.2.3
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-    optionalDependencies:
-      react-native-worklets: 0.11.4(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
-
-  expo-modules-core@57.0.14(e2979a2f17ca9a55c4eb1c16abbca728):
-    dependencies:
-      '@expo/expo-modules-macros-plugin': 0.6.1
-      expo-modules-jsi: 57.0.6(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))
-      invariant: 2.2.4
-      react: 19.2.3
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-    optionalDependencies:
-      react-native-worklets: 0.10.1(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
-
-  expo-modules-core@57.0.14(ec041ae14a641bedf3450fa178b946f2):
-    dependencies:
-      '@expo/expo-modules-macros-plugin': 0.6.1
-      expo-modules-jsi: 57.0.6(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))
+      expo-modules-jsi: 56.0.7(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))
       invariant: 2.2.4
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
@@ -23219,6 +22984,16 @@ snapshots:
       react-native: 0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
     optionalDependencies:
       react-native-worklets: 0.11.4(@babel/core@7.29.0(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
+
+  expo-modules-core@57.0.16(776f50e86d1fa16b8c97f84f36de1b37):
+    dependencies:
+      '@expo/expo-modules-macros-plugin': 0.6.1
+      expo-modules-jsi: 57.0.8(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))
+      invariant: 2.2.4
+      react: 19.2.3
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+    optionalDependencies:
+      react-native-worklets: 0.10.1(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
 
   expo-modules-core@57.0.16(e2979a2f17ca9a55c4eb1c16abbca728):
     dependencies:
@@ -23240,21 +23015,17 @@ snapshots:
     optionalDependencies:
       react-native-worklets: 0.11.4(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
 
-  expo-modules-jsi@56.0.7(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)):
-    dependencies:
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-
-  expo-modules-jsi@57.0.6(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)):
-    dependencies:
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-
-  expo-modules-jsi@57.0.6(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)):
+  expo-modules-jsi@56.0.7(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)):
     dependencies:
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
 
   expo-modules-jsi@57.0.8(react-native@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)):
     dependencies:
       react-native: 0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+
+  expo-modules-jsi@57.0.8(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)):
+    dependencies:
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
 
   expo-modules-jsi@57.0.8(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)):
     dependencies:
@@ -23369,7 +23140,57 @@ snapshots:
       - react-native-worklets
       - supports-color
 
-  expo-router@57.0.19(6fbf87c593f7e175b5adc91463d41515):
+  expo-router@57.0.19(64e24ee6d2d1f55d48af07a1c8d113d1):
+    dependencies:
+      '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      '@expo/metro-runtime': 57.0.15(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      '@expo/schema-utils': 57.0.2
+      '@expo/ui': 57.0.16(0609eed03e06ad4c6d880f425abe60fb)
+      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.15)(react@19.2.3)
+      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.5(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      client-only: 0.0.1
+      color: 4.2.3
+      debug: 4.4.3(supports-color@10.2.2)
+      escape-string-regexp: 4.0.0
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
+      expo-constants: 57.0.17(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(supports-color@10.2.2)
+      expo-glass-effect: 57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      expo-linking: 57.0.9(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
+      expo-server: 57.0.3
+      expo-symbols: 57.0.2(expo-font@57.0.3)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      fast-deep-equal: 3.1.3
+      invariant: 2.2.4
+      nanoid: 3.3.12
+      query-string: 7.1.3
+      react: 19.2.3
+      react-fast-compare: 3.2.2
+      react-is: 19.2.6
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+      react-native-drawer-layout: 4.2.4(react-native-gesture-handler@3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3))(react-native-reanimated@4.6.0(776f50e86d1fa16b8c97f84f36de1b37))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      react-native-safe-area-context: 5.9.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      react-native-screens: 4.27.0(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      server-only: 0.0.1
+      sf-symbols-typescript: 2.2.0
+      shallowequal: 1.1.0
+      standard-navigation: 0.0.5
+      vaul: 1.1.2(@types/react-dom@19.2.5(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    optionalDependencies:
+      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@25.2.3)(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
+      react-dom: 19.2.3(react@19.2.3)
+      react-native-gesture-handler: 3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      react-native-reanimated: 4.6.0(776f50e86d1fa16b8c97f84f36de1b37)
+      react-native-web: 0.21.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@types/react'
+      - '@types/react-dom'
+      - expo-font
+      - react-native-worklets
+      - supports-color
+    optional: true
+
+  expo-router@57.0.19(6da7b9cb5221a62efdf8a9f744f5df86):
     dependencies:
       '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       '@expo/metro-runtime': 57.0.15(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
@@ -23396,7 +23217,7 @@ snapshots:
       react-fast-compare: 3.2.2
       react-is: 19.2.6
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-      react-native-drawer-layout: 4.2.4(react-native-gesture-handler@3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3))(react-native-reanimated@4.6.0(ec041ae14a641bedf3450fa178b946f2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      react-native-drawer-layout: 4.2.4(react-native-gesture-handler@3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3))(react-native-reanimated@4.5.5(ec041ae14a641bedf3450fa178b946f2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       react-native-safe-area-context: 5.9.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       react-native-screens: 4.27.0(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       server-only: 0.0.1
@@ -23408,7 +23229,7 @@ snapshots:
       '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@25.2.3)(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
       react-dom: 19.2.3(react@19.2.3)
       react-native-gesture-handler: 3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      react-native-reanimated: 4.6.0(ec041ae14a641bedf3450fa178b946f2)
+      react-native-reanimated: 4.5.5(ec041ae14a641bedf3450fa178b946f2)
       react-native-web: 0.21.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - '@babel/core'
@@ -23419,7 +23240,7 @@ snapshots:
       - supports-color
     optional: true
 
-  expo-router@57.0.19(96a421b3dfa305f0d6d2398defeb4a2c):
+  expo-router@57.0.19(9a3e256f20652013fddcff365c2f476d):
     dependencies:
       '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       '@expo/metro-runtime': 57.0.15(@expo/log-box@57.0.4)(expo@57.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
@@ -23437,7 +23258,7 @@ snapshots:
       expo-glass-effect: 57.0.1(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       expo-linking: 57.0.9(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
       expo-server: 57.0.3
-      expo-symbols: 57.0.2(expo-font@57.0.3(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3))(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      expo-symbols: 57.0.2(expo-font@57.0.3)(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       fast-deep-equal: 3.1.3
       invariant: 2.2.4
       nanoid: 3.3.12
@@ -23459,56 +23280,6 @@ snapshots:
       react-dom: 19.2.3(react@19.2.3)
       react-native-gesture-handler: 3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       react-native-reanimated: 4.6.0(e2979a2f17ca9a55c4eb1c16abbca728)
-      react-native-web: 0.21.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - '@types/react'
-      - '@types/react-dom'
-      - expo-font
-      - react-native-worklets
-      - supports-color
-    optional: true
-
-  expo-router@57.0.19(d0ac48ab5e3ef0a158fc3a7914224102):
-    dependencies:
-      '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      '@expo/metro-runtime': 57.0.15(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      '@expo/schema-utils': 57.0.2
-      '@expo/ui': 57.0.16(b7aea1f940e916a89a77cd4011839798)
-      '@radix-ui/react-slot': 1.3.3(@types/react@19.2.15)(react@19.2.3)
-      '@radix-ui/react-tabs': 1.1.21(@types/react-dom@19.2.5(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@react-native-masked-view/masked-view': 0.3.2(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      client-only: 0.0.1
-      color: 4.2.3
-      debug: 4.4.3(supports-color@10.2.2)
-      escape-string-regexp: 4.0.0
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
-      expo-constants: 57.0.17(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(supports-color@10.2.2)
-      expo-glass-effect: 57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      expo-linking: 57.0.9(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
-      expo-server: 57.0.3
-      expo-symbols: 57.0.2(expo-font@57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3))(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      fast-deep-equal: 3.1.3
-      invariant: 2.2.4
-      nanoid: 3.3.12
-      query-string: 7.1.3
-      react: 19.2.3
-      react-fast-compare: 3.2.2
-      react-is: 19.2.6
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-      react-native-drawer-layout: 4.2.4(react-native-gesture-handler@3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3))(react-native-reanimated@4.5.5(d550c89ce303cbf8cb44e2ee7fad5837))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      react-native-safe-area-context: 5.9.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      react-native-screens: 4.27.0(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      server-only: 0.0.1
-      sf-symbols-typescript: 2.2.0
-      shallowequal: 1.1.0
-      standard-navigation: 0.0.5
-      vaul: 1.1.2(@types/react-dom@19.2.5(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-    optionalDependencies:
-      '@testing-library/react-native': 13.3.3(jest@29.7.0(@types/node@25.2.3)(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react-test-renderer@19.2.3(react@19.2.3))(react@19.2.3)
-      react-dom: 19.2.3(react@19.2.3)
-      react-native-gesture-handler: 3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      react-native-reanimated: 4.5.5(d550c89ce303cbf8cb44e2ee7fad5837)
       react-native-web: 0.21.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     transitivePeerDependencies:
       - '@babel/core'
@@ -23554,23 +23325,13 @@ snapshots:
 
   expo-structured-headers@57.0.0: {}
 
-  expo-symbols@57.0.2(expo-font@57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3))(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3):
+  expo-symbols@57.0.2(expo-font@57.0.3)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.19
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
       expo-font: 57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-      sf-symbols-typescript: 2.2.0
-    optional: true
-
-  expo-symbols@57.0.2(expo-font@57.0.3(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3))(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3):
-    dependencies:
-      '@expo-google-fonts/material-symbols': 0.4.19
-      expo: 57.0.20(87a0a49f1bf035cc15b0a7018dcdb3f6)
-      expo-font: 57.0.3(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      react: 19.2.3
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
       sf-symbols-typescript: 2.2.0
     optional: true
 
@@ -23596,7 +23357,7 @@ snapshots:
   expo-symbols@57.0.2(expo-font@57.0.3)(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.19
-      expo: 57.0.20(aeab5085f2d0b5696793adf3fe51c1bd)
+      expo: 57.0.20(87a0a49f1bf035cc15b0a7018dcdb3f6)
       expo-font: 57.0.3(expo@57.0.20)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
@@ -23647,53 +23408,10 @@ snapshots:
       expo: 57.0.20(7ee86f2dba25c3be925d72094eb565e5)
       react-native: 0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
 
-  expo@57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec):
-    dependencies:
-      '@babel/runtime': 7.29.7
-      '@expo/cli': 57.0.20(8e12489a441466148eeae54ed24d0d3d)
-      '@expo/config': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/config-plugins': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/devtools': 57.0.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      '@expo/fingerprint': 0.20.11(supports-color@10.2.2)
-      '@expo/local-build-cache-provider': 57.0.8(supports-color@10.2.2)(typescript@6.0.3)
-      '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      '@expo/metro': 56.0.2(supports-color@10.2.2)
-      '@expo/metro-config': 57.0.12(expo@57.0.18)(supports-color@10.2.2)(typescript@6.0.3)
-      '@ungap/structured-clone': 1.3.2
-      babel-preset-expo: 57.0.9(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(expo@57.0.18)(react-refresh@0.14.2)(supports-color@10.2.2)
-      expo-asset: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
-      expo-constants: 57.0.17(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(supports-color@10.2.2)
-      expo-file-system: 57.0.6(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))
-      expo-font: 57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      expo-keep-awake: 57.0.1(expo@57.0.18)(react@19.2.3)
-      expo-modules-autolinking: 57.0.12(supports-color@10.2.2)(typescript@6.0.3)
-      expo-modules-core: 57.0.14(d550c89ce303cbf8cb44e2ee7fad5837)
-      pretty-format: 29.7.0
-      react: 19.2.3
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-      react-refresh: 0.14.2
-      whatwg-url-minimum: 0.1.2
-    optionalDependencies:
-      '@expo/dom-webview': 57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      '@expo/metro-runtime': 57.0.15(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      react-dom: 19.2.3(react@19.2.3)
-      react-native-web: 0.21.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react-native-webview: 14.0.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-    transitivePeerDependencies:
-      - '@babel/core'
-      - bufferutil
-      - expo-router
-      - expo-widgets
-      - react-native-worklets
-      - react-server-dom-webpack
-      - supports-color
-      - typescript
-      - utf-8-validate
-
   expo@57.0.18(87a0a49f1bf035cc15b0a7018dcdb3f6):
     dependencies:
       '@babel/runtime': 7.29.7
-      '@expo/cli': 57.0.20(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/cli': 57.0.22(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
       '@expo/config': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
       '@expo/config-plugins': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
       '@expo/devtools': 57.0.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
@@ -23703,14 +23421,14 @@ snapshots:
       '@expo/metro': 56.0.2(supports-color@10.2.2)
       '@expo/metro-config': 57.0.12(expo@57.0.18)(supports-color@10.2.2)(typescript@6.0.3)
       '@ungap/structured-clone': 1.3.2
-      babel-preset-expo: 57.0.9(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(expo@57.0.18)(react-refresh@0.14.2)(supports-color@10.2.2)
+      babel-preset-expo: 57.0.10(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(expo@57.0.18)(react-refresh@0.14.2)(supports-color@10.2.2)
       expo-asset: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
       expo-constants: 57.0.17(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(supports-color@10.2.2)
       expo-file-system: 57.0.6(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))
       expo-font: 57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       expo-keep-awake: 57.0.1(expo@57.0.18)(react@19.2.3)
       expo-modules-autolinking: 57.0.12(supports-color@10.2.2)(typescript@6.0.3)
-      expo-modules-core: 57.0.14(e2979a2f17ca9a55c4eb1c16abbca728)
+      expo-modules-core: 57.0.16(e2979a2f17ca9a55c4eb1c16abbca728)
       pretty-format: 29.7.0
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
@@ -23733,10 +23451,53 @@ snapshots:
       - typescript
       - utf-8-validate
 
+  expo@57.0.18(908c6b81209f89fab3ab3aff328965fc):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@expo/cli': 57.0.22(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/config': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/config-plugins': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/devtools': 57.0.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      '@expo/fingerprint': 0.20.11(supports-color@10.2.2)
+      '@expo/local-build-cache-provider': 57.0.8(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/log-box': 57.0.4(@expo/dom-webview@57.0.1)(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      '@expo/metro': 56.0.2(supports-color@10.2.2)
+      '@expo/metro-config': 57.0.12(expo@57.0.18)(supports-color@10.2.2)(typescript@6.0.3)
+      '@ungap/structured-clone': 1.3.2
+      babel-preset-expo: 57.0.10(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(expo@57.0.18)(react-refresh@0.14.2)(supports-color@10.2.2)
+      expo-asset: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
+      expo-constants: 57.0.17(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(supports-color@10.2.2)
+      expo-file-system: 57.0.6(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))
+      expo-font: 57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      expo-keep-awake: 57.0.1(expo@57.0.18)(react@19.2.3)
+      expo-modules-autolinking: 57.0.12(supports-color@10.2.2)(typescript@6.0.3)
+      expo-modules-core: 57.0.16(776f50e86d1fa16b8c97f84f36de1b37)
+      pretty-format: 29.7.0
+      react: 19.2.3
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+      react-refresh: 0.14.2
+      whatwg-url-minimum: 0.1.2
+    optionalDependencies:
+      '@expo/dom-webview': 57.0.1(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      '@expo/metro-runtime': 57.0.15(@expo/log-box@57.0.4)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      react-dom: 19.2.3(react@19.2.3)
+      react-native-web: 0.21.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-native-webview: 14.0.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - bufferutil
+      - expo-router
+      - expo-widgets
+      - react-native-worklets
+      - react-server-dom-webpack
+      - supports-color
+      - typescript
+      - utf-8-validate
+
   expo@57.0.18(c117059c9d8da59f92e2e60e68fa7f74):
     dependencies:
       '@babel/runtime': 7.29.7
-      '@expo/cli': 57.0.20(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
+      '@expo/cli': 57.0.22(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo@57.0.18)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
       '@expo/config': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
       '@expo/config-plugins': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
       '@expo/devtools': 57.0.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
@@ -23746,14 +23507,14 @@ snapshots:
       '@expo/metro': 56.0.2(supports-color@10.2.2)
       '@expo/metro-config': 57.0.12(expo@57.0.18)(supports-color@10.2.2)(typescript@6.0.3)
       '@ungap/structured-clone': 1.3.2
-      babel-preset-expo: 57.0.9(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(expo@57.0.18)(react-refresh@0.14.2)(supports-color@10.2.2)
+      babel-preset-expo: 57.0.10(@babel/core@7.29.7(supports-color@10.2.2))(@babel/runtime@7.29.7)(expo@57.0.18)(react-refresh@0.14.2)(supports-color@10.2.2)
       expo-asset: 57.0.16(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
       expo-constants: 57.0.17(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(supports-color@10.2.2)
       expo-file-system: 57.0.6(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))
       expo-font: 57.0.3(expo@57.0.18)(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
       expo-keep-awake: 57.0.1(expo@57.0.18)(react@19.2.3)
       expo-modules-autolinking: 57.0.12(supports-color@10.2.2)(typescript@6.0.3)
-      expo-modules-core: 57.0.14(ec041ae14a641bedf3450fa178b946f2)
+      expo-modules-core: 57.0.16(ec041ae14a641bedf3450fa178b946f2)
       pretty-format: 29.7.0
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
@@ -23822,7 +23583,7 @@ snapshots:
   expo@57.0.20(87a0a49f1bf035cc15b0a7018dcdb3f6):
     dependencies:
       '@babel/runtime': 7.29.7
-      '@expo/cli': 57.0.22(d6b936a442563129ff9ca7125129d3f5)
+      '@expo/cli': 57.0.22(@expo/dom-webview@57.0.1)(@expo/metro-runtime@57.0.15)(expo-constants@57.0.17)(expo-font@57.0.3)(expo-router@57.0.19)(expo@57.0.20)(react-dom@19.2.3(react@19.2.3))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)(typescript@6.0.3)
       '@expo/config': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
       '@expo/config-plugins': 57.0.9(supports-color@10.2.2)(typescript@6.0.3)
       '@expo/devtools': 57.0.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
@@ -24421,12 +24182,6 @@ snapshots:
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
-
-  glob@13.0.0:
-    dependencies:
-      minimatch: 10.2.5
-      minipass: 7.1.2
-      path-scurry: 2.0.1
 
   glob@13.0.6:
     dependencies:
@@ -25333,7 +25088,7 @@ snapshots:
       server-only: 0.0.1
       stacktrace-js: 2.0.2
     optionalDependencies:
-      expo: 57.0.18(6bd2a8f449f7082e2f95bfedec4f9cec)
+      expo: 57.0.18(908c6b81209f89fab3ab3aff328965fc)
     transitivePeerDependencies:
       - '@babel/core'
       - bufferutil
@@ -26548,8 +26303,6 @@ snapshots:
 
   minipass@4.2.8: {}
 
-  minipass@7.1.2: {}
-
   minipass@7.1.3: {}
 
   minisearch@7.2.0: {}
@@ -27060,11 +26813,6 @@ snapshots:
       lru-cache: 10.4.3
       minipass: 7.1.3
 
-  path-scurry@2.0.1:
-    dependencies:
-      lru-cache: 11.2.4
-      minipass: 7.1.2
-
   path-scurry@2.0.2:
     dependencies:
       lru-cache: 11.2.4
@@ -27532,13 +27280,23 @@ snapshots:
       react-native-reanimated: 4.5.5(532e25885bc3770bb4e6d91122b442c2)
       use-latest-callback: 0.2.6(react@19.2.3)
 
-  react-native-drawer-layout@4.2.4(react-native-gesture-handler@3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3))(react-native-reanimated@4.5.5(d550c89ce303cbf8cb44e2ee7fad5837))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3):
+  react-native-drawer-layout@4.2.4(react-native-gesture-handler@3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3))(react-native-reanimated@4.6.0(776f50e86d1fa16b8c97f84f36de1b37))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3):
     dependencies:
       color: 4.2.3
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
       react-native-gesture-handler: 3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      react-native-reanimated: 4.5.5(d550c89ce303cbf8cb44e2ee7fad5837)
+      react-native-reanimated: 4.6.0(776f50e86d1fa16b8c97f84f36de1b37)
+      use-latest-callback: 0.2.6(react@19.2.3)
+    optional: true
+
+  react-native-drawer-layout@4.2.4(react-native-gesture-handler@3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3))(react-native-reanimated@4.5.5(ec041ae14a641bedf3450fa178b946f2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3):
+    dependencies:
+      color: 4.2.3
+      react: 19.2.3
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+      react-native-gesture-handler: 3.2.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      react-native-reanimated: 4.5.5(ec041ae14a641bedf3450fa178b946f2)
       use-latest-callback: 0.2.6(react@19.2.3)
     optional: true
 
@@ -27611,6 +27369,7 @@ snapshots:
     dependencies:
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+    optional: true
 
   react-native-is-edge-to-edge@1.3.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3):
     dependencies:
@@ -27680,13 +27439,22 @@ snapshots:
       react-native-worklets: 0.11.4(@babel/core@7.29.0(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
       semver: 7.8.5
 
-  react-native-reanimated@4.5.5(d550c89ce303cbf8cb44e2ee7fad5837):
+  react-native-reanimated@4.5.5(ec041ae14a641bedf3450fa178b946f2):
+    dependencies:
+      react: 19.2.3
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+      react-native-is-edge-to-edge: 1.3.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
+      react-native-worklets: 0.11.4(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
+      semver: 7.8.5
+
+  react-native-reanimated@4.6.0(776f50e86d1fa16b8c97f84f36de1b37):
     dependencies:
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
       react-native-is-edge-to-edge: 1.3.1(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)
-      react-native-worklets: 0.11.4(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
+      react-native-worklets: 0.10.1(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2)
       semver: 7.8.5
+    optional: true
 
   react-native-reanimated@4.6.0(e2979a2f17ca9a55c4eb1c16abbca728):
     dependencies:
@@ -27834,6 +27602,28 @@ snapshots:
       react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
     optional: true
 
+  react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2):
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/types': 7.29.8
+      '@react-native/metro-config': 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      convert-source-map: 2.0.0
+      react: 19.2.3
+      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
+      semver: 7.8.5
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
+
   react-native-worklets@0.10.1(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2):
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
@@ -27875,29 +27665,6 @@ snapshots:
       convert-source-map: 2.0.0
       react: 19.2.3
       react-native: 0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.0(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
-      semver: 7.8.5
-    transitivePeerDependencies:
-      - supports-color
-
-  react-native-worklets@0.11.4(@babel/core@7.29.7(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(react-native@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2):
-    dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/generator': 7.29.8
-      '@babel/plugin-transform-arrow-functions': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-class-properties': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-classes': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-nullish-coalescing-operator': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-optional-chaining': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-transform-shorthand-properties': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-template-literals': 7.27.1(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-unicode-regex': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/traverse': 7.29.8(supports-color@10.2.2)
-      '@babel/types': 7.29.8
-      '@react-native/metro-config': 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      convert-source-map: 2.0.0
-      react: 19.2.3
-      react-native: 0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(@react-native-community/cli@20.2.0(supports-color@10.2.2)(typescript@6.0.3))(@react-native/jest-preset@0.85.3(@babel/core@7.29.7(supports-color@10.2.2))(react@19.2.3)(supports-color@10.2.2))(@react-native/metro-config@0.86.3(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@types/react@19.2.15)(react@19.2.3)(supports-color@10.2.2)
       semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
@@ -29174,8 +28941,6 @@ snapshots:
   tailwindcss@4.2.2: {}
 
   tailwindcss@4.3.3: {}
-
-  tapable@2.3.0: {}
 
   tapable@2.3.3: {}
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
 	"references": [
 		{ "path": "./apps/mobile/tsconfig.json" },
 		{ "path": "./packages/orpheus/tsconfig.json" },
+		{ "path": "./packages/dlna/tsconfig.json" },
 		{ "path": "./packages/image-theme-colors/tsconfig.json" },
 		{ "path": "./apps/docs/tsconfig.json" },
 		{ "path": "./packages/splash/tsconfig.json" },


### PR DESCRIPTION
## Summary
- Add `@bbplayer/dlna` to discover LAN MediaRenderers, proxy Bilibili/local audio, and control UPnP Play/Pause/Seek/Stop/volume.
- Wire the player UI so skip, progress, lyrics, and play/pause stay in sync with the speaker; disconnect returns playback to the phone.
- Avoid guessing RenderingControl URLs and keep stream UA/Referer in one place so headers match Orpheus.

## Test plan
- [ ] On Android, open the player, tap cast, discover a speaker on the same Wi-Fi, and start playback
- [ ] Pause/resume, seek, skip next/prev, and confirm the speaker track changes
- [ ] Volume keys follow speaker volume when the device exposes RenderingControl
- [ ] Disconnect from the current device row; speaker stops and the phone resumes at the same position
- [ ] Local downloaded tracks also cast


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - Android 端支持发现局域网 DLNA 设备，并将当前音乐投放至兼容设备。
  - 支持投放设备的播放、暂停、切歌、进度调整、断开及本地播放恢复。
  - 播放器新增投放入口、设备状态展示和播放进度同步。
  - 歌词定位、播放队列及自动切歌兼容 DLNA 投放。

- **改进**
  - 优化播放控制、进度显示与动画表现，提升播放稳定性和流畅度。
  - 改善投放失败及进度调整失败时的状态恢复。
  - 投放期间隐藏频谱可视化，减少不适用的本地播放效果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->